### PR TITLE
Add template helper scripts, update templates

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -22,7 +22,7 @@ RUN yum -y install epel-release \
 
 ENV PATH=/calyptos/bin:$PATH
 
-ADD [ "calyptos", "host-*.sh", "/calyptos/bin/" ]
+ADD [ "calyptos", "host-*.sh", "template-*.sh", "/calyptos/bin/" ]
 ADD [ "templates", "/calyptos/templates/" ]
 
 RUN chown --recursive root:root /calyptos \

--- a/deploy/template-env.sh
+++ b/deploy/template-env.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Generate an environment yaml from a template
+set -euo pipefail
+IFS=$'\n\t'
+
+TEMP_FILE="${1:--}"
+HOSTS_FILE="${2:-}"
+HOST_NAMES_FILE="${3:-}"
+PUBLIC_IP_RANGES_FILE="${4:-}"
+PRIVATE_IP_RANGES_FILE="${5:-}"
+
+declare -A TEMPLATE_VAR_MAP=(
+  ["ETP_DNS_SERVER"]="${ETP_DNS_SERVER:-ETP_DNS_SERVER}"
+  ["ETP_EUCA2OOLS_YUM_REPO"]="${ETP_EUCA2OOLS_YUM_REPO:-http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/}"
+  ["ETP_EUCALYPTUS_BRANCH"]="${ETP_EUCALYPTUS_BRANCH:-devel-4.4}"
+  ["ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH"]="${ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH:-devel-4.4}"
+  ["ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO"]="${ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO:-https://github.com/sjones4/eucalyptus-cloud-libs.git}"
+  ["ETP_EUCALYPTUS_CLOUD_OPTS"]="${ETP_EUCALYPTUS_CLOUD_OPTS:-}"
+  ["ETP_EUCALYPTUS_DNS_DOMAIN"]="${ETP_EUCALYPTUS_DNS_DOMAIN:-ETP_HOST0_IP.nip.io}"
+  ["ETP_EUCALYPTUS_GIT_REPO"]="${ETP_EUCALYPTUS_GIT_REPO:-https://github.com/sjones4/eucalyptus.git}"
+  ["ETP_EUCALYPTUS_YUM_REPO"]="${ETP_EUCALYPTUS_YUM_REPO:-http://downloads.eucalyptus.com/software/eucalyptus/4.4/rhel/7/x86_64/}"
+  ["ETP_GATEWAY"]="${ETP_GATEWAY:-ETP_GATEWAY}"
+  ["ETP_INSTALL_TYPE"]="${ETP_INSTALL_TYPE:-packages}"
+  ["ETP_NETMASK"]="${ETP_NETMASK:-255.255.255.0}"
+  ["ETP_NTP_SERVER"]="${ETP_NTP_SERVER:-ETP_NTP_SERVER}"
+  ["ETP_PRIVATE_IP_RANGE"]="${ETP_PRIVATE_IP_RANGE:-ETP_PRIVATE_IP_RANGE}"
+  ["ETP_PUBLIC_IP_RANGE"]="${ETP_PUBLIC_IP_RANGE:-ETP_PUBLIC_IP_RANGE}"
+  ["ETP_SUBNET"]="${ETP_SUBNET:-ETP_SUBNET}"
+)
+
+# checks
+if [ "${TEMP_FILE}" != "-" ] && [ ! -f "${TEMP_FILE}" ] ; then
+  echo "Template not found: ${TEMP_FILE}" >&2
+  exit 1
+fi
+
+for OPTIONAL_FILE_PARAM in HOSTS_FILE HOST_NAMES_FILE PUBLIC_IP_RANGES_FILE PRIVATE_IP_RANGES_FILE; do
+  if [ ! -z "${!OPTIONAL_FILE_PARAM}" ] && [ ! -f "${!OPTIONAL_FILE_PARAM}" ] ; then
+    echo "File not found: ${!OPTIONAL_FILE_PARAM}" >&2
+    exit 1
+  fi
+done
+
+# working template
+TEMPLATE_TEMP=$(mktemp -t environment.yaml.XXXXXXXX)
+function cleanup {
+  [ ! -f "${TEMPLATE_TEMP}" ] || rm -f "${TEMPLATE_TEMP}"
+}
+trap cleanup EXIT
+cat "${TEMP_FILE}" > "${TEMPLATE_TEMP}"
+
+# add dynamic template variables
+if [ ! -z "${HOSTS_FILE}" ] ; then
+  HOST_NUM=0
+  for HOST in $(<"${HOSTS_FILE}"); do
+    TEMPLATE_VAR_MAP["ETP_HOST${HOST_NUM}_IP"]="${HOST}"
+    HOST_NUM=$((HOST_NUM + 1))
+  done
+fi
+if [ ! -z "${HOST_NAMES_FILE}" ] ; then
+  HOST_NUM=0
+  for HOST in $(<"${HOST_NAMES_FILE}"); do
+    TEMPLATE_VAR_MAP["ETP_HOST${HOST_NUM}_NAME"]="${HOST}"
+    HOST_NUM=$((HOST_NUM + 1))
+  done
+fi
+if [ -z "${ETP_PUBLIC_IP_RANGE}" ] && [ ! -z "${PUBLIC_IP_RANGES_FILE}" ] ; then
+  IP_RANGES=""
+  for IP_RANGE in $(<"${PUBLIC_IP_RANGES_FILE}"); do
+    if [ ! -z "${IP_RANGES}" ] ; then IP_RANGES="${IP_RANGES}, " ; fi
+    IP_RANGES="${IP_RANGES}'${IP_RANGE}'"
+  done
+  TEMPLATE_VAR_MAP["ETP_PUBLIC_IP_RANGE"]="${IP_RANGES}"
+fi
+if [ -z "${ETP_PRIVATE_IP_RANGE}" ] && [ ! -z "${PRIVATE_IP_RANGES_FILE}" ] ; then
+  IP_RANGES=""
+  for IP_RANGE in $(<"${PRIVATE_IP_RANGES_FILE}"); do
+    if [ ! -z "${IP_RANGES}" ] ; then IP_RANGES="${IP_RANGES}, " ; fi
+    IP_RANGES="${IP_RANGES}'${IP_RANGE}'"
+  done
+  TEMPLATE_VAR_MAP["ETP_PRIVATE_IP_RANGE"]="${IP_RANGES}"
+fi
+
+#process
+PROCESS_TEMPLATE=1
+PROCESS_COUNT=0
+while [ ${PROCESS_TEMPLATE} -gt 0 ] && [ ${PROCESS_COUNT} -lt 10 ]; do
+  for TEMPLATE_VAR in "${!TEMPLATE_VAR_MAP[@]}"; do
+    sed --in-place "s/${TEMPLATE_VAR}/${TEMPLATE_VAR_MAP[$TEMPLATE_VAR]//\//\\/}/g" "${TEMPLATE_TEMP}"
+  done
+  PROCESS_TEMPLATE=$(grep -c ETP_ "${TEMPLATE_TEMP}" || true)
+  PROCESS_COUNT=$((PROCESS_COUNT + 1))
+done
+
+cat "${TEMPLATE_TEMP}"
+exit ${PROCESS_TEMPLATE}

--- a/deploy/template-info.sh
+++ b/deploy/template-info.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Get metadata for a template
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TEMP_FILE="${1:--}"
+TEMP_INFO="${2:-vars}"
+
+function template_env( ) {
+  "${SCRIPT_DIR}/template-env.sh"
+}
+
+function template_stream( ) {
+  cat "${TEMP_FILE}"
+}
+
+function template_variables_filter( ) {
+  grep -Pzo 'ETP_[A-Z0-9_]{1,128}' | sed 's/ETP_/\nETP_/g' | grep -a ETP | sort -uV
+}
+
+if [ "${TEMP_FILE}" != "-" ] && [ ! -f "${TEMP_FILE}" ] ; then
+  echo "Template not found: ${TEMP_FILE}" >&2
+  exit 1
+fi
+
+if [ "${TEMP_INFO}" = "vars" ] ; then
+  template_stream | template_variables_filter
+elif [ "${TEMP_INFO}" = "required-vars" ] ; then
+  template_stream | template_env | template_variables_filter
+elif [ "${TEMP_INFO}" = "host-count" ] ; then
+  template_stream | template_variables_filter | grep '^ETP_HOST[0-9]*_IP$' | wc -l
+else
+  echo "Template info not supported: ${TEMP_INFO}" >&2
+  exit 1
+fi
+
+exit 0

--- a/deploy/templates/cloud-in-a-box-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-environment.yaml
@@ -22,28 +22,28 @@ default_attributes:
       services.imaging.worker.ntp_server: ETP_NTP_SERVER
       services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
     topology:
-      clc: [ ETP_HOST0 ]
+      clc: [ ETP_HOST0_IP ]
       objectstorage:
         providerclient: walrus
-        walrusbackend: [ ETP_HOST0 ]
-      user-facing: [ ETP_HOST0 ]
+        walrusbackend: [ ETP_HOST0_IP ]
+      user-facing: [ ETP_HOST0_IP ]
       clusters:
         one:
           storage-backend: overlay
-          cc: [ ETP_HOST0 ]
-          sc: [ ETP_HOST0 ]
-          nodes: [ ETP_HOST0 ]
+          cc: [ ETP_HOST0_IP ]
+          sc: [ ETP_HOST0_IP ]
+          nodes: [ ETP_HOST0_IP ]
     nc:
       max-cores: 32
       cache-size: 50000
       work-size: 250000
     network:
       mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0 ]
-      PublicIps: [ 'ETP_PUBLIC_IP_RANGE' ]
+      InstanceDnsServers: [ ETP_HOST0_IP ]
+      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
       clusters:
         - Name: one
-          PrivateIps: [ 'ETP_PRIVATE_IP_RANGE' ]
+          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
           Subnet:
             Subnet: ETP_SUBNET
             Name: ETP_SUBNET
@@ -53,7 +53,7 @@ default_attributes:
       public-interface: br0
       private-interface: br0
       bridged-nic: eno1
-      bridge-ip: ETP_HOST0
+      bridge-ip: ETP_HOST0_IP
       bridge-netmask: ETP_NETMASK
       bridge-gateway: ETP_GATEWAY
       dns-server: ETP_DNS_SERVER

--- a/deploy/templates/cloud-in-a-box-with-console-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-with-console-environment.yaml
@@ -22,29 +22,29 @@ default_attributes:
       services.imaging.worker.ntp_server: ETP_NTP_SERVER
       services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
     topology:
-      clc: [ ETP_HOST0 ]
+      clc: [ ETP_HOST0_IP ]
       objectstorage:
         providerclient: walrus
-        walrusbackend: [ ETP_HOST0 ]
-      user-facing: [ ETP_HOST0 ]
-      console: [ ETP_HOST0 ]
+        walrusbackend: [ ETP_HOST0_IP ]
+      user-facing: [ ETP_HOST0_IP ]
+      console: [ ETP_HOST0_IP ]
       clusters:
         one:
           storage-backend: overlay
-          cc: [ ETP_HOST0 ]
-          sc: [ ETP_HOST0 ]
-          nodes: [ ETP_HOST0 ]
+          cc: [ ETP_HOST0_IP ]
+          sc: [ ETP_HOST0_IP ]
+          nodes: [ ETP_HOST0_IP ]
     nc:
       max-cores: 32
       cache-size: 50000
       work-size: 250000
     network:
       mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0 ]
-      PublicIps: [ 'ETP_PUBLIC_IP_RANGE' ]
+      InstanceDnsServers: [ ETP_HOST0_IP ]
+      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
       clusters:
         - Name: one
-          PrivateIps: [ 'ETP_PRIVATE_IP_RANGE' ]
+          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
           Subnet:
             Subnet: ETP_SUBNET
             Name: ETP_SUBNET
@@ -54,7 +54,7 @@ default_attributes:
       public-interface: br0
       private-interface: br0
       bridged-nic: eno1
-      bridge-ip: ETP_HOST0
+      bridge-ip: ETP_HOST0_IP
       bridge-netmask: ETP_NETMASK
       bridge-gateway: ETP_GATEWAY
       dns-server: ETP_DNS_SERVER


### PR DESCRIPTION
Template scripts added to extract metadata for templates (variables used, number of hosts required) and to generate an environment by populating a template.

Templates are updated to avoid ambiguous with host variables, i.e. ETP_HOST1 vs ETP_HOST10 and to allow multiple IP ranges in substitutions.