### PR TITLE
Prevent creation of autom4te.cache in source dirs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,7 @@ RUN chown --recursive root:root /root/bin/*.sh \
  && chmod 755 /root/bin/*.sh \
  && mkdir --parents /eucalyptus \
  && chown --recursive root:root /eucalyptus \
+ && build-all-rpms-44.sh setupenv \
  && build-eucalyptus-cloud-libs-rpm.sh setup \
  && build-eucalyptus-rpms.sh setup \
  && build-eucalyptus-selinux-rpm.sh setup \

--- a/build/build-all-rpms-44.sh
+++ b/build/build-all-rpms-44.sh
@@ -2,6 +2,15 @@
 # Build all eucalyptus rpms for the 4.4 series
 set -e
 
+if [ "${1:-}" = "setupenv" ] ; then
+  cat > "${HOME}/.autom4te.cfg" <<"AUTOCONF"
+begin-language: "Autoconf-without-aclocal-m4"
+args: --no-cache
+end-language: "Autoconf-without-aclocal-m4"
+AUTOCONF
+  exit 0
+fi
+
 # dependencies
 yum -y install "httpd" # create /var/www/
 


### PR DESCRIPTION
Disable use of the autom4te.cache autoconf cache with the docker image as the ownership of this directory can prevent clean up of source git repository clones.