### PR TITLE
Ceph deployment support

### DIFF
--- a/deploy/template-env.sh
+++ b/deploy/template-env.sh
@@ -4,12 +4,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 TEMP_FILE="${1:--}"
-HOSTS_FILE="${2:-}"
-HOST_NAMES_FILE="${3:-}"
-PUBLIC_IP_RANGES_FILE="${4:-}"
-PRIVATE_IP_RANGES_FILE="${5:-}"
+TEMP_ALIAS_FILE="${2:-}"
+HOSTS_FILE="${3:-}"
+HOST_NAMES_FILE="${4:-}"
+PUBLIC_IP_RANGES_FILE="${5:-}"
+PRIVATE_IP_RANGES_FILE="${6:-}"
 
 declare -A TEMPLATE_VAR_MAP=(
+  ["ETP_CEPH_POOL_SNAPSHOTS"]="${ETP_CEPH_POOL_SNAPSHOTS:-eucasnapshots}"
+  ["ETP_CEPH_POOL_VOLUMES"]="${ETP_CEPH_POOL_VOLUMES:-eucavolumes}"
+  ["ETP_CEPH_RBD_KEY"]="${ETP_CEPH_RBD_KEY:-ETP_CEPH_RBD_KEY}"
+  ["ETP_CEPH_S3_ACCESS_KEY"]="${ETP_CEPH_S3_ACCESS_KEY:-ETP_CEPH_S3_ACCESS_KEY}"
+  ["ETP_CEPH_S3_ENDPOINT"]="${ETP_CEPH_S3_ENDPOINT:-127.0.0.1:7480}"
+  ["ETP_CEPH_S3_SECRET_KEY"]="${ETP_CEPH_S3_SECRET_KEY:-ETP_CEPH_S3_SECRET_KEY}"
+  ["ETP_CLUSTER_MAX_INSTANCES"]="${ETP_CLUSTER_MAX_INSTANCES:-128}"
+  ["ETP_CLUSTER_SCHEDULING_POLICY"]="${ETP_CLUSTER_SCHEDULING_POLICY:-ROUNDROBIN}"
   ["ETP_DAS_DEVICE"]="${ETP_DAS_DEVICE:-storage_vg}"
   ["ETP_DNS_SERVER"]="${ETP_DNS_SERVER:-ETP_DNS_SERVER}"
   ["ETP_EUCA2OOLS_YUM_REPO"]="${ETP_EUCA2OOLS_YUM_REPO:-http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/}"
@@ -23,7 +32,10 @@ declare -A TEMPLATE_VAR_MAP=(
   ["ETP_GATEWAY"]="${ETP_GATEWAY:-ETP_GATEWAY}"
   ["ETP_INSTALL_TYPE"]="${ETP_INSTALL_TYPE:-packages}"
   ["ETP_NETMASK"]="${ETP_NETMASK:-255.255.255.0}"
+  ["ETP_NODE_CACHE_SIZE"]="${ETP_NODE_CACHE_SIZE:--1}"
+  ["ETP_NODE_MAX_CORES"]="${ETP_NODE_MAX_CORES:-0}"
   ["ETP_NODE_NIC"]="${ETP_NODE_NIC:-eno1}"
+  ["ETP_NODE_WORK_SIZE"]="${ETP_NODE_WORK_SIZE:--1}"
   ["ETP_NTP_SERVER"]="${ETP_NTP_SERVER:-ETP_NTP_SERVER}"
   ["ETP_PRIVATE_IP_RANGE"]="${ETP_PRIVATE_IP_RANGE:-ETP_PRIVATE_IP_RANGE}"
   ["ETP_PUBLIC_IP_RANGE"]="${ETP_PUBLIC_IP_RANGE:-ETP_PUBLIC_IP_RANGE}"
@@ -36,7 +48,7 @@ if [ "${TEMP_FILE}" != "-" ] && [ ! -f "${TEMP_FILE}" ] ; then
   exit 1
 fi
 
-for OPTIONAL_FILE_PARAM in HOSTS_FILE HOST_NAMES_FILE PUBLIC_IP_RANGES_FILE PRIVATE_IP_RANGES_FILE; do
+for OPTIONAL_FILE_PARAM in TEMP_ALIAS_FILE HOSTS_FILE HOST_NAMES_FILE PUBLIC_IP_RANGES_FILE PRIVATE_IP_RANGES_FILE; do
   if [ ! -z "${!OPTIONAL_FILE_PARAM}" ] && [ ! -f "${!OPTIONAL_FILE_PARAM}" ] ; then
     echo "File not found: ${!OPTIONAL_FILE_PARAM}" >&2
     exit 1
@@ -49,7 +61,15 @@ function cleanup {
   [ ! -f "${TEMPLATE_TEMP}" ] || rm -f "${TEMPLATE_TEMP}"
 }
 trap cleanup EXIT
-cat "${TEMP_FILE}" > "${TEMPLATE_TEMP}"
+TEMPLATE_ALIAS_COUNT=$(grep -c ETP_TEMPLATE_ALIASES "${TEMP_FILE}" 2>/dev/null || true)
+if [ ${TEMPLATE_ALIAS_COUNT} -gt 0 ] && [ ! -z "${TEMP_ALIAS_FILE}" ] ; then
+  grep -B 1000 ETP_TEMPLATE_ALIASES "${TEMP_FILE}" | grep -v ETP_TEMPLATE_ALIASES > "${TEMPLATE_TEMP}"
+  echo "template_aliases:" >> "${TEMPLATE_TEMP}"
+  sed 's/^/    /' "${TEMP_ALIAS_FILE}" >> "${TEMPLATE_TEMP}"
+  grep -A 1000 ETP_TEMPLATE_ALIASES "${TEMP_FILE}" | grep -v ETP_TEMPLATE_ALIASES >> "${TEMPLATE_TEMP}"
+else
+  cat "${TEMP_FILE}" > "${TEMPLATE_TEMP}"
+fi
 
 # add dynamic template variables
 if [ ! -z "${HOSTS_FILE}" ] ; then
@@ -66,7 +86,7 @@ if [ ! -z "${HOST_NAMES_FILE}" ] ; then
     HOST_NUM=$((HOST_NUM + 1))
   done
 fi
-if [ -z "${ETP_PUBLIC_IP_RANGE}" ] && [ ! -z "${PUBLIC_IP_RANGES_FILE}" ] ; then
+if [ -z "${ETP_PUBLIC_IP_RANGE:-}" ] && [ ! -z "${PUBLIC_IP_RANGES_FILE}" ] ; then
   IP_RANGES=""
   for IP_RANGE in $(<"${PUBLIC_IP_RANGES_FILE}"); do
     if [ ! -z "${IP_RANGES}" ] ; then IP_RANGES="${IP_RANGES}, " ; fi
@@ -74,7 +94,7 @@ if [ -z "${ETP_PUBLIC_IP_RANGE}" ] && [ ! -z "${PUBLIC_IP_RANGES_FILE}" ] ; then
   done
   TEMPLATE_VAR_MAP["ETP_PUBLIC_IP_RANGE"]="${IP_RANGES}"
 fi
-if [ -z "${ETP_PRIVATE_IP_RANGE}" ] && [ ! -z "${PRIVATE_IP_RANGES_FILE}" ] ; then
+if [ -z "${ETP_PRIVATE_IP_RANGE:-}" ] && [ ! -z "${PRIVATE_IP_RANGES_FILE}" ] ; then
   IP_RANGES=""
   for IP_RANGE in $(<"${PRIVATE_IP_RANGES_FILE}"); do
     if [ ! -z "${IP_RANGES}" ] ; then IP_RANGES="${IP_RANGES}, " ; fi

--- a/deploy/template-info.sh
+++ b/deploy/template-info.sh
@@ -7,9 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TEMP_FILE="${1:--}"
 TEMP_INFO="${2:-vars}"
+TEMP_ALIAS_FILE="${3:-}"
 
 function template_env( ) {
-  "${SCRIPT_DIR}/template-env.sh"
+  "${SCRIPT_DIR}/template-env.sh" ${TEMP_INFO}
 }
 
 function template_stream( ) {

--- a/deploy/templates/cloud-in-a-box-das-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-das-environment.yaml
@@ -1,62 +1,46 @@
+---
 name: ciab-das
 description: 'Eucalyptus cloud-in-a-box using das storage'
+template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
-  eucalyptus:
-    source-branch: ETP_EUCALYPTUS_BRANCH
-    source-repo: ETP_EUCALYPTUS_GIT_REPO
-    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
-    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
-    selinux-branch: master
-    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
-    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
-    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
-    yum-options: '--nogpg'
-    install-type: ETP_INSTALL_TYPE
-    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
-    cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
-    cloud-properties:
-      bootstrap.webservices.async_internal_operations: true
-      bootstrap.webservices.server_pool_max_threads: 128
-      cloudformation.url_domain_whitelist: '*s3.amazonaws.com'
-      services.imaging.worker.instance_type: m1.medium
-      services.imaging.worker.ntp_server: ETP_NTP_SERVER
-      services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
-    topology:
-      clc: [ ETP_HOST0_IP ]
-      objectstorage:
-        providerclient: walrus
-        walrusbackend: [ ETP_HOST0_IP ]
-      user-facing: [ ETP_HOST0_IP ]
-      clusters:
-        one:
-          storage-backend: das
-          das-device: ETP_DAS_DEVICE
-          cc: [ ETP_HOST0_IP ]
-          sc: [ ETP_HOST0_IP ]
-          nodes: [ ETP_HOST0_IP ]
-    nc:
-      max-cores: 32
-      cache-size: 50000
-      work-size: 250000
-    network:
-      mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0_IP ]
-      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
-      clusters:
-        - Name: one
-          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
-          Subnet:
-            Subnet: ETP_SUBNET
-            Name: ETP_SUBNET
-            Netmask: ETP_NETMASK
-            Gateway: ETP_GATEWAY
-      bridge-interface: br0
-      public-interface: br0
-      private-interface: br0
-      bridged-nic: ETP_NODE_NIC
-      bridge-ip: ETP_HOST0_IP
-      bridge-netmask: ETP_NETMASK
-      bridge-gateway: ETP_GATEWAY
-      dns-server: ETP_DNS_SERVER
+    eucalyptus:
+        <<: *alias_eucalyptus
+        cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
+        cloud-properties:
+            <<: *alias_eucalyptus_cloud_properties
+        topology:
+            clc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            objectstorage:
+                providerclient: walrus
+                walrusbackend: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            clusters:
+                one:
+                    storage-backend: das
+                    das-device: ETP_DAS_DEVICE
+                    cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    nodes: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+        cc:
+            <<: *alias_eucalyptus_cc
+        nc:
+            <<: *alias_eucalyptus_nc
+        network:
+            mode: EDGE
+            InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            PublicIps: [ETP_PUBLIC_IP_RANGE]
+            clusters:
+                - Name: one
+                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
+                  Subnet:
+                      Subnet: ETP_SUBNET
+                      Name: ETP_SUBNET
+                      Netmask: ETP_NETMASK
+                      Gateway: ETP_GATEWAY
+            bridge-interface: br0
+            public-interface: br0
+            private-interface: br0
+            bridged-nic: ETP_NODE_NIC
+            dns-server: ETP_DNS_SERVER
 override_attributes: {}
 cookbook_versions: {}

--- a/deploy/templates/cloud-in-a-box-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-environment.yaml
@@ -1,61 +1,45 @@
+---
 name: ciab
 description: 'Eucalyptus minimal cloud-in-a-box'
+template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
-  eucalyptus:
-    source-branch: ETP_EUCALYPTUS_BRANCH
-    source-repo: ETP_EUCALYPTUS_GIT_REPO
-    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
-    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
-    selinux-branch: master
-    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
-    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
-    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
-    yum-options: '--nogpg'
-    install-type: ETP_INSTALL_TYPE
-    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
-    cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
-    cloud-properties:
-      bootstrap.webservices.async_internal_operations: true
-      bootstrap.webservices.server_pool_max_threads: 128
-      cloudformation.url_domain_whitelist: '*s3.amazonaws.com'
-      services.imaging.worker.instance_type: m1.medium
-      services.imaging.worker.ntp_server: ETP_NTP_SERVER
-      services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
-    topology:
-      clc: [ ETP_HOST0_IP ]
-      objectstorage:
-        providerclient: walrus
-        walrusbackend: [ ETP_HOST0_IP ]
-      user-facing: [ ETP_HOST0_IP ]
-      clusters:
-        one:
-          storage-backend: overlay
-          cc: [ ETP_HOST0_IP ]
-          sc: [ ETP_HOST0_IP ]
-          nodes: [ ETP_HOST0_IP ]
-    nc:
-      max-cores: 32
-      cache-size: 50000
-      work-size: 250000
-    network:
-      mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0_IP ]
-      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
-      clusters:
-        - Name: one
-          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
-          Subnet:
-            Subnet: ETP_SUBNET
-            Name: ETP_SUBNET
-            Netmask: ETP_NETMASK
-            Gateway: ETP_GATEWAY
-      bridge-interface: br0
-      public-interface: br0
-      private-interface: br0
-      bridged-nic: ETP_NODE_NIC
-      bridge-ip: ETP_HOST0_IP
-      bridge-netmask: ETP_NETMASK
-      bridge-gateway: ETP_GATEWAY
-      dns-server: ETP_DNS_SERVER
+    eucalyptus:
+        <<: *alias_eucalyptus
+        cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
+        cloud-properties:
+            <<: *alias_eucalyptus_cloud_properties
+        topology:
+            clc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            objectstorage:
+                providerclient: walrus
+                walrusbackend: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            clusters:
+                one:
+                    storage-backend: overlay
+                    cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    nodes: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+        cc:
+            <<: *alias_eucalyptus_cc
+        nc:
+            <<: *alias_eucalyptus_nc
+        network:
+            mode: EDGE
+            InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            PublicIps: [ETP_PUBLIC_IP_RANGE]
+            clusters:
+                - Name: one
+                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
+                  Subnet:
+                      Subnet: ETP_SUBNET
+                      Name: ETP_SUBNET
+                      Netmask: ETP_NETMASK
+                      Gateway: ETP_GATEWAY
+            bridge-interface: br0
+            public-interface: br0
+            private-interface: br0
+            bridged-nic: ETP_NODE_NIC
+            dns-server: ETP_DNS_SERVER
 override_attributes: {}
 cookbook_versions: {}

--- a/deploy/templates/cloud-in-a-box-with-console-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-with-console-environment.yaml
@@ -1,62 +1,46 @@
+---
 name: ciab-console
 description: 'Eucalyptus cloud-in-a-box, including eucaconsole'
+template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
-  eucalyptus:
-    source-branch: ETP_EUCALYPTUS_BRANCH
-    source-repo: ETP_EUCALYPTUS_GIT_REPO
-    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
-    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
-    selinux-branch: master
-    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
-    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
-    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
-    yum-options: '--nogpg'
-    install-type: ETP_INSTALL_TYPE
-    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
-    cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
-    cloud-properties:
-      bootstrap.webservices.async_internal_operations: true
-      bootstrap.webservices.server_pool_max_threads: 128
-      cloudformation.url_domain_whitelist: '*s3.amazonaws.com'
-      services.imaging.worker.instance_type: m1.medium
-      services.imaging.worker.ntp_server: ETP_NTP_SERVER
-      services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
-    topology:
-      clc: [ ETP_HOST0_IP ]
-      objectstorage:
-        providerclient: walrus
-        walrusbackend: [ ETP_HOST0_IP ]
-      user-facing: [ ETP_HOST0_IP ]
-      console: [ ETP_HOST0_IP ]
-      clusters:
-        one:
-          storage-backend: overlay
-          cc: [ ETP_HOST0_IP ]
-          sc: [ ETP_HOST0_IP ]
-          nodes: [ ETP_HOST0_IP ]
-    nc:
-      max-cores: 32
-      cache-size: 50000
-      work-size: 250000
-    network:
-      mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0_IP ]
-      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
-      clusters:
-        - Name: one
-          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
-          Subnet:
-            Subnet: ETP_SUBNET
-            Name: ETP_SUBNET
-            Netmask: ETP_NETMASK
-            Gateway: ETP_GATEWAY
-      bridge-interface: br0
-      public-interface: br0
-      private-interface: br0
-      bridged-nic: ETP_NODE_NIC
-      bridge-ip: ETP_HOST0_IP
-      bridge-netmask: ETP_NETMASK
-      bridge-gateway: ETP_GATEWAY
-      dns-server: ETP_DNS_SERVER
+    eucalyptus:
+        <<: *alias_eucalyptus
+        cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
+        cloud-properties:
+            <<: *alias_eucalyptus_cloud_properties
+        topology:
+            clc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            objectstorage:
+                providerclient: walrus
+                walrusbackend: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            console: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            clusters:
+                one:
+                    storage-backend: overlay
+                    cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    nodes: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+        cc:
+            <<: *alias_eucalyptus_cc
+        nc:
+            <<: *alias_eucalyptus_nc
+        network:
+            mode: EDGE
+            InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            PublicIps: [ETP_PUBLIC_IP_RANGE]
+            clusters:
+                - Name: one
+                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
+                  Subnet:
+                      Subnet: ETP_SUBNET
+                      Name: ETP_SUBNET
+                      Netmask: ETP_NETMASK
+                      Gateway: ETP_GATEWAY
+            bridge-interface: br0
+            public-interface: br0
+            private-interface: br0
+            bridged-nic: ETP_NODE_NIC
+            dns-server: ETP_DNS_SERVER
 override_attributes: {}
 cookbook_versions: {}

--- a/deploy/templates/edge-ceph-environment.yaml
+++ b/deploy/templates/edge-ceph-environment.yaml
@@ -1,5 +1,6 @@
-name: edge-multinode
-description: 'Eucalyptus cloud with edge networking, das storage, 2 nodes'
+---
+name: edge-ceph
+description: 'Eucalyptus cloud with edge networking and ceph'
 template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
     eucalyptus:
@@ -7,19 +8,34 @@ default_attributes:
         cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
         cloud-properties:
             <<: *alias_eucalyptus_cloud_properties
+            one.storage.cephconfigfile: /etc/ceph/ceph.conf
+            one.storage.cephkeyringfile:
+                /etc/ceph/ceph.client.eucalyptus.keyring
+            one.storage.cephsnapshotpools: ETP_CEPH_POOL_SNAPSHOTS
+            one.storage.cephuser: eucalyptus
+            one.storage.cephvolumepools: ETP_CEPH_POOL_VOLUMES
+        ceph-config:
+            <<: *alias_eucalyptus_ceph_config
+        ceph-keyrings:
+            rbd-user:
+                key: ETP_CEPH_RBD_KEY
+                keyring: /etc/ceph/ceph.client.eucalyptus.keyring
+                name: client.eucalyptus
         topology:
             clc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
             objectstorage:
-                providerclient: walrus
-                walrusbackend: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                providerclient: ceph-rgw
+                access-key: ETP_CEPH_S3_ACCESS_KEY
+                secret-key: ETP_CEPH_S3_SECRET_KEY
+                ceph-radosgw:
+                    endpoint: ETP_CEPH_S3_ENDPOINT
             user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
             clusters:
                 one:
-                    storage-backend: das
-                    das-device: ETP_DAS_DEVICE
+                    storage-backend: ceph-rbd
                     cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
                     sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
-                    nodes: [ETP_HOST1_IP ETP_HOST2_IP]  # ETP_HOST1_NAME ETP_HOST2_NAME
+                    nodes: [ETP_HOST1_IP]  # ETP_HOST1_NAME
         cc:
             <<: *alias_eucalyptus_cc
         nc:
@@ -43,3 +59,4 @@ default_attributes:
             dns-server: ETP_DNS_SERVER
 override_attributes: {}
 cookbook_versions: {}
+

--- a/deploy/templates/edge-environment.yaml
+++ b/deploy/templates/edge-environment.yaml
@@ -1,59 +1,46 @@
+---
 name: edge
 description: 'Eucalyptus cloud with edge networking and das storage'
+template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
-  eucalyptus:
-    source-branch: ETP_EUCALYPTUS_BRANCH
-    source-repo: ETP_EUCALYPTUS_GIT_REPO
-    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
-    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
-    selinux-branch: master
-    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
-    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
-    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
-    yum-options: '--nogpg'
-    install-type: ETP_INSTALL_TYPE
-    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
-    cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
-    cloud-properties:
-      bootstrap.webservices.async_internal_operations: true
-      bootstrap.webservices.server_pool_max_threads: 128
-      cloudformation.url_domain_whitelist: '*s3.amazonaws.com'
-      services.imaging.worker.instance_type: m1.medium
-      services.imaging.worker.ntp_server: ETP_NTP_SERVER
-      services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
-    topology:
-      clc: [ ETP_HOST0_IP ]
-      objectstorage:
-        providerclient: walrus
-        walrusbackend: [ ETP_HOST0_IP ]
-      user-facing: [ ETP_HOST0_IP ]
-      clusters:
-        one:
-          storage-backend: das
-          das-device: ETP_DAS_DEVICE
-          cc: [ ETP_HOST0_IP ]
-          sc: [ ETP_HOST0_IP ]
-          nodes: [ ETP_HOST1_IP ]
-    nc:
-      max-cores: 32
-      cache-size: 50000
-      work-size: 250000
-    network:
-      mode: EDGE
-      InstanceDnsServers: [ ETP_HOST0_IP ]
-      PublicIps: [ ETP_PUBLIC_IP_RANGE ]
-      clusters:
-        - Name: one
-          PrivateIps: [ ETP_PRIVATE_IP_RANGE ]
-          Subnet:
-            Subnet: ETP_SUBNET
-            Name: ETP_SUBNET
-            Netmask: ETP_NETMASK
-            Gateway: ETP_GATEWAY
-      bridge-interface: br0
-      public-interface: br0
-      private-interface: br0
-      bridged-nic: ETP_NODE_NIC
-      dns-server: ETP_DNS_SERVER
+    eucalyptus:
+        <<: *alias_eucalyptus
+        cloud-opts: 'ETP_EUCALYPTUS_CLOUD_OPTS'
+        cloud-properties:
+            <<: *alias_eucalyptus_cloud_properties
+        topology:
+            clc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            objectstorage:
+                providerclient: walrus
+                walrusbackend: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            clusters:
+                one:
+                    storage-backend: das
+                    das-device: ETP_DAS_DEVICE
+                    cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+                    nodes: [ETP_HOST1_IP]  # ETP_HOST1_NAME
+        cc:
+            <<: *alias_eucalyptus_cc
+        nc:
+            <<: *alias_eucalyptus_nc
+        network:
+            mode: EDGE
+            InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            PublicIps: [ETP_PUBLIC_IP_RANGE]
+            clusters:
+                - Name: one
+                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
+                  Subnet:
+                      Subnet: ETP_SUBNET
+                      Name: ETP_SUBNET
+                      Netmask: ETP_NETMASK
+                      Gateway: ETP_GATEWAY
+            bridge-interface: br0
+            public-interface: br0
+            private-interface: br0
+            bridged-nic: ETP_NODE_NIC
+            dns-server: ETP_DNS_SERVER
 override_attributes: {}
 cookbook_versions: {}

--- a/deploy/templates/snippet-default-template-aliases.yaml
+++ b/deploy/templates/snippet-default-template-aliases.yaml
@@ -1,0 +1,34 @@
+# common aliases that can be used in templates
+alias-eucalyptus: &alias_eucalyptus
+    source-branch: ETP_EUCALYPTUS_BRANCH
+    source-repo: ETP_EUCALYPTUS_GIT_REPO
+    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
+    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
+    selinux-branch: master
+    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
+    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
+    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
+    yum-options: '--nogpg'
+    install-type: ETP_INSTALL_TYPE
+    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
+alias-eucalyptus-cloud-properties: &alias_eucalyptus_cloud_properties
+    services.imaging.worker.ntp_server: ETP_NTP_SERVER
+    services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
+alias-eucalyptus-cc: &alias_eucalyptus_cc
+    max-instances-per-cc: ETP_CLUSTER_MAX_INSTANCES
+    scheduling-policy: ETP_CLUSTER_SCHEDULING_POLICY
+alias-eucalyptus-nc: &alias_eucalyptus_nc
+    max-cores: ETP_NODE_MAX_CORES
+    cache-size: ETP_NODE_CACHE_SIZE
+    work-size: ETP_NODE_WORK_SIZE
+alias-eucalyptus-ceph-config: &alias_eucalyptus_ceph_config
+    global:
+        cluster network: ETP_SUBNET/16
+        fsid: FSID_GOES_HERE
+        max open files: '131072'
+        mon host: MON_HOSTNAMES_GO_HERE
+        mon initial members: MON_INITIAL_MEMBER_IPS_GO_HERE
+        public network: ETP_SUBNET/16
+    mon.FIRST_MON_HOSTNAME_GOES_HERE:
+        host: FIRST_MON_HOSTNAME_GOES_HERE
+        mon addr: FIRST_MON_IP_GOES_HERE:6789

--- a/jenkins/eucalyptus-44-build-cloud-libs-rpm/config.xml
+++ b/jenkins/eucalyptus-44-build-cloud-libs-rpm/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,18 +19,18 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus-cloud-libs/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>CLOUD_LIBS_GIT_REPO</name>
-          <description></description>
+          <description/>
           <defaultValue>https://github.com/sjones4/eucalyptus-cloud-libs.git</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>CLOUD_LIBS_GIT_BRANCH</name>
-          <description></description>
+          <description/>
           <defaultValue>devel-4.4</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
@@ -72,23 +71,23 @@ mkdir -v rpms
 chmod 777 rpms
 
 # build
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/eucalyptus-builder:4.4
 fi
 docker run --rm \
   --env RPM_DIST=${EUCALYPTUS_GLOBAL_RPM_DIST:-el7} \
   --env RPM_OUT=/eucalyptus/rpms \
-  -v &quot;$(pwd)&quot;:/eucalyptus \
+  -v "$(pwd)":/eucalyptus \
   -w /eucalyptus \
   sjones4/eucalyptus-builder:4.4 \
   build-eucalyptus-cloud-libs-rpm.sh build-only</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command># sign rpms
-if [ ! -z &quot;${EUCALYPTUS_GLOBAL_DEV_GPG_KEY+x}&quot; ] ; then
+if [ ! -z "${EUCALYPTUS_GLOBAL_DEV_GPG_KEY+x}" ] ; then
   docker run --rm \
-    --env GPG_KEY=&quot;${EUCALYPTUS_GLOBAL_DEV_GPG_KEY}&quot; \
-    -v &quot;$(pwd)&quot;:/eucalyptus \
+    --env GPG_KEY="${EUCALYPTUS_GLOBAL_DEV_GPG_KEY}" \
+    -v "$(pwd)":/eucalyptus \
     -w /eucalyptus/rpms \
     sjones4/eucalyptus-builder:4.4 \
     rpm-sign.sh

--- a/jenkins/eucalyptus-44-build-release-rpms/config.xml
+++ b/jenkins/eucalyptus-44-build-release-rpms/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -23,7 +22,7 @@
         <hudson.model.StringParameterDefinition>
           <name>BUILD_LABEL</name>
           <description>e.g. rc1</description>
-          <defaultValue></defaultValue>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -42,14 +41,14 @@
 [ ! -d rpms ]          || rm -rf rpms
 
 EUCALYPTUS_REPO_DIRS=(
-  &quot;eucaconsole&quot;
-  &quot;eucaconsole-selinux&quot;
-  &quot;eucalyptus-cloud-libs&quot;
-  &quot;eucalyptus&quot;
-  &quot;eucalyptus-selinux&quot;
+  "eucaconsole"
+  "eucaconsole-selinux"
+  "eucalyptus-cloud-libs"
+  "eucalyptus"
+  "eucalyptus-selinux"
 )
-for EUCALYPTUS_REPO_DIR in &quot;${EUCALYPTUS_REPO_DIRS[@]}&quot;; do
-  [ ! -d &quot;${EUCALYPTUS_REPO_DIR}&quot; ] || rm -rf &quot;${EUCALYPTUS_REPO_DIR}&quot;
+for EUCALYPTUS_REPO_DIR in "${EUCALYPTUS_REPO_DIRS[@]}"; do
+  [ ! -d "${EUCALYPTUS_REPO_DIR}" ] || rm -rf "${EUCALYPTUS_REPO_DIR}"
 done
 
 # create rpmbuild dirs
@@ -72,55 +71,55 @@ git clone --depth 1 --branch devel-4.4 https://github.com/sjones4/eucalyptus.git
 git clone --depth 1 --branch master    https://github.com/eucalyptus/eucalyptus-selinux.git
 
 # build
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/eucalyptus-builder:4.4
 fi
 
-export RPM_DIST=&quot;${EUCALYPTUS_GLOBAL_RPM_DIST:-el7}&quot;
-if [ ! -z &quot;${BUILD_LABEL}&quot; ] ; then
-  export RPM_BUILD_ID=&quot;${BUILD_ID}.${BUILD_LABEL}&quot;
+export RPM_DIST="${EUCALYPTUS_GLOBAL_RPM_DIST:-el7}"
+if [ ! -z "${BUILD_LABEL}" ] ; then
+  export RPM_BUILD_ID="${BUILD_ID}.${BUILD_LABEL}"
 else
-  export RPM_BUILD_ID=&quot;${BUILD_ID}&quot;
+  export RPM_BUILD_ID="${BUILD_ID}"
 fi
 EUCALYPTUS_BUILD_SCRIPTS=(
-  &quot;build-eucalyptus-console-rpm.sh&quot;
-  &quot;build-eucalyptus-console-selinux-rpm.sh&quot;
-  &quot;build-eucalyptus-cloud-libs-rpm.sh&quot;
-  &quot;build-eucalyptus-rpms.sh&quot;
-  &quot;build-eucalyptus-selinux-rpm.sh&quot;
+  "build-eucalyptus-console-rpm.sh"
+  "build-eucalyptus-console-selinux-rpm.sh"
+  "build-eucalyptus-cloud-libs-rpm.sh"
+  "build-eucalyptus-rpms.sh"
+  "build-eucalyptus-selinux-rpm.sh"
 )
-for EUCALYPTUS_BUILD_SCRIPT in &quot;${EUCALYPTUS_BUILD_SCRIPTS[@]}&quot; ; do
+for EUCALYPTUS_BUILD_SCRIPT in "${EUCALYPTUS_BUILD_SCRIPTS[@]}" ; do
   docker run --rm \
     --env RPM_DIST \
     --env RPM_BUILD_ID \
     --env RPM_OUT=/eucalyptus/rpms \
     --env RPMBUILD=/eucalyptus/rpmbuild \
-    -v &quot;$(pwd)&quot;:/eucalyptus \
+    -v "$(pwd)":/eucalyptus \
     -w /eucalyptus \
     sjones4/eucalyptus-builder:4.4 \
-    &quot;${EUCALYPTUS_BUILD_SCRIPT}&quot; build-only
+    "${EUCALYPTUS_BUILD_SCRIPT}" build-only
 done
 
 # log versions / commits
-LOG_FILE=&quot;build-audit.log&quot;
-[ ! -f &quot;${LOG_FILE}&quot; ] || rm -f &quot;${LOG_FILE}&quot;
+LOG_FILE="build-audit.log"
+[ ! -f "${LOG_FILE}" ] || rm -f "${LOG_FILE}"
 
-docker images sjones4/eucalyptus-builder | tee &quot;${LOG_FILE}&quot;
+docker images sjones4/eucalyptus-builder | tee "${LOG_FILE}"
 
 # log sources
-for EUCALYPTUS_REPO_DIR in &quot;${EUCALYPTUS_REPO_DIRS[@]}&quot;; do
-  printf &apos;%-22s&apos; &quot;${EUCALYPTUS_REPO_DIR}&quot; | tee &quot;${LOG_FILE}&quot;
-  git --git-dir=&quot;${EUCALYPTUS_REPO_DIR}/.git&quot; log --max-count=1 --pretty=oneline --no-decorate | tee &quot;${LOG_FILE}&quot;
+for EUCALYPTUS_REPO_DIR in "${EUCALYPTUS_REPO_DIRS[@]}"; do
+  printf '%-22s' "${EUCALYPTUS_REPO_DIR}" | tee "${LOG_FILE}"
+  git --git-dir="${EUCALYPTUS_REPO_DIR}/.git" log --max-count=1 --pretty=oneline --no-decorate | tee "${LOG_FILE}"
 done
 
-cat &quot;${LOG_FILE}&quot;</command>
+cat "${LOG_FILE}"</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command># sign rpms
-[ ! -z &quot;${GPG_KEY+x}&quot; ] || exit 1
+[ ! -z "${GPG_KEY+x}" ] || exit 1
 docker run --rm \
   --env GPG_KEY \
-  -v &quot;$(pwd)&quot;:/eucalyptus \
+  -v "$(pwd)":/eucalyptus \
   -w /eucalyptus/rpms \
   sjones4/eucalyptus-builder:4.4 \
   rpm-sign.sh

--- a/jenkins/eucalyptus-44-build-rpms/config.xml
+++ b/jenkins/eucalyptus-44-build-rpms/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,18 +19,18 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>EUCALYPTUS_GIT_REPO</name>
-          <description></description>
+          <description/>
           <defaultValue>https://github.com/sjones4/eucalyptus.git</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>EUCALYPTUS_GIT_BRANCH</name>
-          <description></description>
+          <description/>
           <defaultValue>devel-4.4</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
@@ -84,7 +83,7 @@ mkdir -pv rpmbuild/RPMS/x86_64
       <project>eucalyptus-44-build-cloud-libs-rpm</project>
       <filter>**/*.rpm</filter>
       <target>rpmbuild/RPMS/noarch/</target>
-      <excludes></excludes>
+      <excludes/>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
         <stable>true</stable>
       </selector>
@@ -98,24 +97,24 @@ mkdir -v rpms
 chmod 777 rpms
 
 # build
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/eucalyptus-builder:4.4
 fi
 docker run --rm \
   --env RPM_DIST=${EUCALYPTUS_GLOBAL_RPM_DIST:-el7} \
   --env RPM_OUT=/eucalyptus/rpms \
   --env RPMBUILD=/eucalyptus/rpmbuild \
-  -v &quot;$(pwd)&quot;:/eucalyptus \
+  -v "$(pwd)":/eucalyptus \
   -w /eucalyptus \
   sjones4/eucalyptus-builder:4.4 \
   build-eucalyptus-rpms.sh build-only</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command># sign rpms
-if [ ! -z &quot;${EUCALYPTUS_GLOBAL_DEV_GPG_KEY+x}&quot; ] ; then
+if [ ! -z "${EUCALYPTUS_GLOBAL_DEV_GPG_KEY+x}" ] ; then
   docker run --rm \
-    --env GPG_KEY=&quot;${EUCALYPTUS_GLOBAL_DEV_GPG_KEY}&quot; \
-    -v &quot;$(pwd)&quot;:/eucalyptus \
+    --env GPG_KEY="${EUCALYPTUS_GLOBAL_DEV_GPG_KEY}" \
+    -v "$(pwd)":/eucalyptus \
     -w /eucalyptus/rpms \
     sjones4/eucalyptus-builder:4.4 \
     rpm-sign.sh

--- a/jenkins/eucalyptus-44-qa-deploy-template-aliases/config.xml
+++ b/jenkins/eucalyptus-44-qa-deploy-template-aliases/config.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
+      <useBuildBlocker>false</useBuildBlocker>
+      <blockLevel>GLOBAL</blockLevel>
+      <scanQueueFor>DISABLED</scanQueueFor>
+      <blockingJobs></blockingJobs>
+    </hudson.plugins.buildblocker.BuildBlockerProperty>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>10</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.TextParameterDefinition>
+          <name>TEMPLATE_ALIASES</name>
+          <description>Define aliases that will be available in all environment templates.</description>
+          <defaultValue># common aliases that can be used in templates
+alias-eucalyptus: &amp;alias_eucalyptus
+    source-branch: ETP_EUCALYPTUS_BRANCH
+    source-repo: ETP_EUCALYPTUS_GIT_REPO
+    cloud-libs-branch: ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH
+    cloud-libs-repo: ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO
+    selinux-branch: master
+    selinux-repo: https://github.com/eucalyptus/eucalyptus-selinux
+    eucalyptus-repo: ETP_EUCALYPTUS_YUM_REPO
+    euca2ools-repo: ETP_EUCA2OOLS_YUM_REPO
+    yum-options: &apos;--nogpg&apos;
+    install-type: ETP_INSTALL_TYPE
+    dns-domain: ETP_EUCALYPTUS_DNS_DOMAIN
+alias-eucalyptus-cloud-properties: &amp;alias_eucalyptus_cloud_properties
+    services.imaging.worker.ntp_server: ETP_NTP_SERVER
+    services.loadbalancing.worker.ntp_server: ETP_NTP_SERVER
+alias-eucalyptus-cc: &amp;alias_eucalyptus_cc
+    max-instances-per-cc: ETP_CLUSTER_MAX_INSTANCES
+    scheduling-policy: ETP_CLUSTER_SCHEDULING_POLICY
+alias-eucalyptus-nc: &amp;alias_eucalyptus_nc
+    max-cores: ETP_NODE_MAX_CORES
+    cache-size: ETP_NODE_CACHE_SIZE
+    work-size: ETP_NODE_WORK_SIZE
+alias-eucalyptus-ceph-config: &amp;alias_eucalyptus_ceph_config
+    global:
+        cluster network: ETP_SUBNET/16
+        fsid: FSID_GOES_HERE
+        max open files: &apos;131072&apos;
+        mon host: MON_HOSTNAMES_GO_HERE
+        mon initial members: MON_INITIAL_MEMBER_IPS_GO_HERE
+        public network: ETP_SUBNET/16
+    mon.FIRST_MON_HOSTNAME_GOES_HERE:
+        host: FIRST_MON_HOSTNAME_GOES_HERE
+        mon addr: FIRST_MON_IP_GOES_HERE:6789</defaultValue>
+        </hudson.model.TextParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>echo &quot;${TEMPLATE_ALIASES}&quot; &gt; template_aliases.yaml</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>template_aliases.yaml</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.9"/>
+  </buildWrappers>
+</project>

--- a/jenkins/eucalyptus-44-qa-deploy/config.xml
+++ b/jenkins/eucalyptus-44-qa-deploy/config.xml
@@ -29,8 +29,12 @@
           <description></description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
+              <string>cloud-in-a-box-das</string>
               <string>cloud-in-a-box</string>
               <string>cloud-in-a-box-with-console</string>
+              <string>edge-ceph</string>
+              <string>edge</string>
+              <string>edge-multinode</string>
               <string>CUSTOM_ENV_TEMPLATE</string>
             </a>
           </choices>
@@ -89,8 +93,8 @@ http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/</descripti
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>EUCALYPTUS_DNS_DOMAIN</name>
-          <description></description>
-          <defaultValue>ETP_HOST0_IP.nip.io</defaultValue>
+          <description>Defaults to EUCALYPTUS_GLOBAL_EUCALYPTUS_DNS_DOMAIN if set, else ETP_HOST0_IP.nip.io</description>
+          <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>NET_PUBLIC_IP_RANGE</name>
@@ -127,6 +131,27 @@ http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/</descripti
           <description>Defaults to EUCALYPTUS_GLOBAL_NTP_SERVER</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>NODE_MAX_CORES</name>
+          <description>Defaults to EUCALYPTUS_GLOBAL_NODE_MAX_CORES if set, else 0 for available cores on each node</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CLUSTER_MAX_INSTANCES</name>
+          <description>Defaults to EUCALYPTUS_GLOBAL_CLUSTER_MAX_INSTANCES if set, else 128</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CLUSTER_SCHEDULING_POLICY</name>
+          <description>Defaults to EUCALYPTUS_GLOBAL_CLUSTER_SCHEDULING_POLICY if set, else ROUNDROBIN</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string></string>
+              <string>GREEDY</string>
+              <string>ROUNDROBIN</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>HOST_PARAM_CPU</name>
           <description>Minimum core requirement for candidate hosts</description>
@@ -145,11 +170,11 @@ http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/</descripti
           <description></description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
+              <string>8</string>
               <string>16</string>
               <string>32</string>
               <string>64</string>
               <string>128</string>
-              <string>256</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
@@ -174,6 +199,17 @@ http://downloads.eucalyptus.com/software/euca2ools/3.4/rhel/7/x86_64/</descripti
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
+    <hudson.plugins.copyartifact.CopyArtifact plugin="copyartifact@1.39">
+      <project>eucalyptus-44-qa-deploy-template-aliases</project>
+      <filter></filter>
+      <target></target>
+      <excludes></excludes>
+      <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
+        <stable>true</stable>
+      </selector>
+      <flatten>true</flatten>
+      <doNotFingerprintArtifacts>true</doNotFingerprintArtifacts>
+    </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.tasks.Shell>
       <command>if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
   echo &quot;Pulling latest calyptos docker image&quot;
@@ -183,6 +219,7 @@ fi
 echo &quot;Extracting resource requirements from environment template&quot;
 [ ! -d env ] || rm -rf env
 mkdir -v env
+mv -v template_aliases.yaml env/
 
 TEMPLATE_PATH=&quot;/calyptos/templates/${ENV_TEMPLATE}-environment.yaml&quot;
 if [ &quot;${ENV_TEMPLATE}&quot; = &quot;CUSTOM_ENV_TEMPLATE&quot; ] ; then
@@ -277,21 +314,34 @@ for HOST in $(&lt;env/reserved_hosts.txt); do
 done
 find reservations -type f
 
-ENV_TEMPLATE_VARS_FILE=&quot;env/template-variables.txt&quot;
+ENV_TEMPLATE_VARS_FILE=&quot;env/template_variables.txt&quot;
 echo &quot;Building environment template variables file ${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;# Environment template variables for ${BUILD_ID}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_POOL_SNAPSHOTS=${EUCALYPTUS_GLOBAL_CEPH_POOL_SNAPSHOTS:-eucasnapshots}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_POOL_VOLUMES=${EUCALYPTUS_GLOBAL_CEPH_POOL_VOLUMES:-eucavolumes}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_RBD_KEY=${EUCALYPTUS_GLOBAL_CEPH_RBD_KEY}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_S3_ACCESS_KEY=${EUCALYPTUS_GLOBAL_CEPH_S3_ACCESS_KEY}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_S3_ENDPOINT=${EUCALYPTUS_GLOBAL_CEPH_S3_ENDPOINT:-127.0.0.1:7480}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CEPH_S3_SECRET_KEY=${EUCALYPTUS_GLOBAL_CEPH_S3_SECRET_KEY}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CLUSTER_MAX_INSTANCES=${CLUSTER_MAX_INSTANCES:-${EUCALYPTUS_GLOBAL_CLUSTER_MAX_INSTANCES:-128}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_CLUSTER_SCHEDULING_POLICY=${CLUSTER_SCHEDULING_POLICY:-${EUCALYPTUS_GLOBAL_CLUSTER_SCHEDULING_POLICY:-ROUNDROBIN}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_DAS_DEVICE=${EUCALYPTUS_GLOBAL_DAS_DEVICE:-storage_vg}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_DNS_SERVER=${DNS_SERVER:-${EUCALYPTUS_GLOBAL_DNS_SERVER}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCA2OOLS_YUM_REPO=${EUCA2OOLS_YUM_REPO:-${EUCALYPTUS_GLOBAL_EUCA2OOLS_YUM_REPO}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_BRANCH=${EUCALYPTUS_GIT_BRANCH}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_CLOUD_LIBS_BRANCH=${CLOUD_LIBS_GIT_BRANCH}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_CLOUD_LIBS_GIT_REPO=${CLOUD_LIBS_GIT_REPO}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_CLOUD_OPTS=${EUCALYPTUS_GLOBAL_CLOUD_OPTS} ${CLOUD_OPTS}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
-echo &quot;ETP_EUCALYPTUS_DNS_DOMAIN=${EUCALYPTUS_DNS_DOMAIN}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_EUCALYPTUS_DNS_DOMAIN=${EUCALYPTUS_DNS_DOMAIN:-${EUCALYPTUS_GLOBAL_EUCALYPTUS_DNS_DOMAIN:-ETP_HOST0_IP.nip.io}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_GIT_REPO=${EUCALYPTUS_GIT_REPO}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_EUCALYPTUS_YUM_REPO=${EUCALYPTUS_YUM_REPO:-${EUCALYPTUS_GLOBAL_EUCALYPTUS_YUM_REPO}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_GATEWAY=${NET_GATEWAY:-${EUCALYPTUS_GLOBAL_NET_GATEWAY}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_INSTALL_TYPE=${INSTALL_TYPE}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_NETMASK=${NET_NETMASK:-${EUCALYPTUS_GLOBAL_NET_NETMASK}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_NODE_CACHE_SIZE=${EUCALYPTUS_GLOBAL_NODE_CACHE_SIZE:--1}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_NODE_MAX_CORES=${NODE_MAX_CORES:-${EUCALYPTUS_GLOBAL_NODE_MAX_CORES:-0}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_NODE_NIC=${EUCALYPTUS_GLOBAL_NODE_NIC:-eno1}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
+echo &quot;ETP_NODE_WORK_SIZE=${EUCALYPTUS_GLOBAL_NODE_WORK_SIZE:--1}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_NTP_SERVER=${NTP_SERVER:-${EUCALYPTUS_GLOBAL_NTP_SERVER}}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_PRIVATE_IP_RANGE=${NET_PRIVATE_IP_RANGE}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
 echo &quot;ETP_PUBLIC_IP_RANGE=${NET_PUBLIC_IP_RANGE}&quot; &gt;&gt; &quot;${ENV_TEMPLATE_VARS_FILE}&quot;
@@ -303,6 +353,7 @@ TEMPLATE_PATH=&quot;/calyptos/templates/${ENV_TEMPLATE}-environment.yaml&quot;
 if [ &quot;${ENV_TEMPLATE}&quot; = &quot;CUSTOM_ENV_TEMPLATE&quot; ] ; then
   TEMPLATE_PATH=&quot;/env/template-environment.yaml&quot;
 fi
+TEMPLATE_ALIAS_PATH=&quot;/env/template_aliases.yaml&quot;
 docker run --rm \
   --env-file &quot;${ENV_TEMPLATE_VARS_FILE}&quot; \
   -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
@@ -310,6 +361,7 @@ docker run --rm \
   sjones4/calyptos:4.4 \
   template-env.sh \
   &quot;${TEMPLATE_PATH}&quot; \
+  &quot;${TEMPLATE_ALIAS_PATH}&quot; \
   &quot;/env/reserved_hosts.txt&quot; \
   &quot;/env/reserved_host_names.txt&quot; \
   &quot;/env/reserved_public_ip_ranges.txt&quot; \
@@ -321,7 +373,7 @@ cat --number env/environment.yaml
 
 for HOST in $(&lt;env/reserved_hosts.txt); do
   echo &quot;Koaning CentOS 7 on ${HOST}&quot;
-  ssh -i &quot;${SSH_KEY_FILE}&quot; -o BatchMode=yes -o UserKnownHostsFile=&quot;${SSH_KNOWNHOSTS}&quot; -o StrictHostKeyChecking=no root@${HOST} &quot;yum -y install epel-release; yum -y install koan &amp;&amp; koan --server=${EUCALYPTUS_GLOBAL_COBBLER_SERVER} --system=\$(hostname) --replace-self &amp;&amp; shutdown -r&quot;
+  ssh -i &quot;${SSH_KEY_FILE}&quot; -o BatchMode=yes -o UserKnownHostsFile=&quot;${SSH_KNOWNHOSTS}&quot; -o StrictHostKeyChecking=no root@${HOST} &quot;yum -y install epel-release; yum -y install koan &amp;&amp; koan --server=${EUCALYPTUS_GLOBAL_COBBLER_SERVER} --system=\$(hostname  | cut -d &apos;.&apos; -f 1) --replace-self &amp;&amp; shutdown -r&quot;
 done
 
 echo &quot;Sleeping 120 to allow CentOS 7 install to start&quot;

--- a/jenkins/eucalyptus-44-qa-fast/config.xml
+++ b/jenkins/eucalyptus-44-qa-fast/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,14 +19,14 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/n4j/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>CLC_IP</name>
-          <description></description>
-          <defaultValue></defaultValue>
+          <description/>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -47,18 +46,18 @@
 mkdir -v results
 chmod 777 cache results
 
-if [ ! -z &quot;${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}&quot; ] ; then
-  export N4J_OPTS=&quot;${N4J_OPTS} -Dcache=/n4j/cache -Dn4j.image.hvm-url=${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}/CentOS-7-x86_64-GenericCloud.raw.tar.gz&quot;
+if [ ! -z "${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}" ] ; then
+  export N4J_OPTS="${N4J_OPTS} -Dcache=/n4j/cache -Dn4j.image.hvm-url=${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}/CentOS-7-x86_64-GenericCloud.raw.tar.gz"
 fi
 
 # run
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/n4j:4.4
 fi
 docker run --rm \
   --env N4J_OPTS \
-  -v &quot;${WORKSPACE}/cache&quot;:/n4j/cache \
-  -v &quot;${WORKSPACE}/results&quot;:/n4j/results \
+  -v "${WORKSPACE}/cache":/n4j/cache \
+  -v "${WORKSPACE}/results":/n4j/results \
   sjones4/n4j:4.4 ./n4j.sh ${CLC_IP}</command>
     </hudson.tasks.Shell>
   </builders>

--- a/jenkins/eucalyptus-44-qa-nephoria/config.xml
+++ b/jenkins/eucalyptus-44-qa-nephoria/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,14 +19,14 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/eucalyptus/nephoria/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>CLC_IP</name>
-          <description></description>
-          <defaultValue></defaultValue>
+          <description/>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -43,30 +42,30 @@
     <hudson.tasks.Shell>
       <command># ssh key setup
 SSH_KEY_DIR=$(mktemp -dt ssh.XXXXXXXX)
-SSH_KEY_FILE=&quot;${SSH_KEY_DIR}/id_rsa&quot;
-SSH_KNOWNHOSTS=&quot;${SSH_KEY_DIR}/known_hosts&quot;
+SSH_KEY_FILE="${SSH_KEY_DIR}/id_rsa"
+SSH_KNOWNHOSTS="${SSH_KEY_DIR}/known_hosts"
 function cleanup {
-  echo &quot;Performing cleanup&quot;
-  [ ! -d &quot;${SSH_KEY_DIR}&quot; ] || rm -rf &quot;${SSH_KEY_DIR}&quot;
+  echo "Performing cleanup"
+  [ ! -d "${SSH_KEY_DIR}" ] || rm -rf "${SSH_KEY_DIR}"
 }
 trap cleanup EXIT
-echo &quot;-----BEGIN RSA PRIVATE KEY-----&quot; &gt; &quot;${SSH_KEY_FILE}&quot;
-echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed &quot;s/ /\n/g&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-echo &quot;-----END RSA PRIVATE KEY-----&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-chmod 600 &quot;${SSH_KEY_FILE}&quot;
-ssh-keygen -y -f &quot;${SSH_KEY_FILE}&quot; &gt; &quot;${SSH_KEY_DIR}/id_rsa.pub&quot;
+echo "-----BEGIN RSA PRIVATE KEY-----" &gt; "${SSH_KEY_FILE}"
+echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed "s/ /\n/g" &gt;&gt; "${SSH_KEY_FILE}"
+echo "-----END RSA PRIVATE KEY-----" &gt;&gt; "${SSH_KEY_FILE}"
+chmod 600 "${SSH_KEY_FILE}"
+ssh-keygen -y -f "${SSH_KEY_FILE}" &gt; "${SSH_KEY_DIR}/id_rsa.pub"
 
 [ ! -d nephoria_results ] || rm -rf nephoria_results
 mkdir -v nephoria_results
 chmod 777 nephoria_results
 
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/nephoria:4.4
 fi
 docker run --rm \
-  --env IMAGE_BASE_URL=&quot;${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}&quot; \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
-  -v &quot;${WORKSPACE}&quot;:/workspace \
+  --env IMAGE_BASE_URL="${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}" \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
+  -v "${WORKSPACE}":/workspace \
   -w /workspace \
   sjones4/nephoria:4.4 \
   nephoria-test.sh ${CLC_IP}</command>

--- a/jenkins/eucalyptus-44-qa-suite/config.xml
+++ b/jenkins/eucalyptus-44-qa-suite/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,14 +19,14 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/n4j/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>CLC_IP</name>
-          <description></description>
-          <defaultValue></defaultValue>
+          <description/>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>TEST_SUITE</name>
@@ -75,19 +74,19 @@
 mkdir -v results
 chmod 777 cache results
 
-if [ ! -z &quot;${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}&quot; ] ; then
-  export N4J_OPTS=&quot;${N4J_OPTS} -Dcache=/n4j/cache -Dn4j.image.hvm-url=${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}/CentOS-7-x86_64-GenericCloud.raw.tar.gz&quot;
+if [ ! -z "${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}" ] ; then
+  export N4J_OPTS="${N4J_OPTS} -Dcache=/n4j/cache -Dn4j.image.hvm-url=${EUCALYPTUS_GLOBAL_IMAGE_BASE_URL}/CentOS-7-x86_64-GenericCloud.raw.tar.gz"
 fi
 
 # run
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
   docker pull sjones4/n4j:4.4
 fi
 docker run --rm \
   --env N4J_OPTS \
-  -v &quot;${WORKSPACE}/cache&quot;:/n4j/cache \
-  -v &quot;${WORKSPACE}/results&quot;:/n4j/results \
-  sjones4/n4j:4.4 ./n4j.sh ${CLC_IP} &quot;com/eucalyptus/tests/suites/${TEST_SUITE}Suite&quot;</command>
+  -v "${WORKSPACE}/cache":/n4j/cache \
+  -v "${WORKSPACE}/results":/n4j/results \
+  sjones4/n4j:4.4 ./n4j.sh ${CLC_IP} "com/eucalyptus/tests/suites/${TEST_SUITE}Suite"</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jenkins/eucalyptus-host-config/config.xml
+++ b/jenkins/eucalyptus-host-config/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,7 +19,7 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus-extras/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
@@ -32,8 +31,8 @@ IP_FQDN_PUBIPRANGE_PRIVIPRANGE_CPUX_DISKX_MEMX_USEX
 
 Remove the last X to temporarily disable a host.
 
-Generally you would copy the &lt;a href=&quot;/job/eucalyptus-host-config/lastSuccessfulBuild/artifact/hosts.txt&quot;&gt;last value&lt;/a&gt; and edit it.</description>
-          <defaultValue></defaultValue>
+Generally you would copy the &lt;a href="/job/eucalyptus-host-config/lastSuccessfulBuild/artifact/hosts.txt"&gt;last value&lt;/a&gt; and edit it.</description>
+          <defaultValue/>
         </hudson.model.TextParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -47,7 +46,7 @@ Generally you would copy the &lt;a href=&quot;/job/eucalyptus-host-config/lastSu
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>echo &quot;${HOSTS}&quot; &gt; hosts.txt</command>
+      <command>echo "${HOSTS}" &gt; hosts.txt</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jenkins/eucalyptus-host-release/config.xml
+++ b/jenkins/eucalyptus-host-release/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,14 +19,14 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus-extras/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>RESERVATION_ID</name>
           <description>e.g. user-123</description>
-          <defaultValue></defaultValue>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -44,7 +43,7 @@
       <project>eucalyptus-host-config</project>
       <filter>hosts.txt</filter>
       <target>hosts/</target>
-      <excludes></excludes>
+      <excludes/>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
         <stable>true</stable>
       </selector>
@@ -54,41 +53,41 @@
     <hudson.tasks.Shell>
       <command># ssh key setup
 SSH_KEY_DIR=$(mktemp -dt ssh.XXXXXXXX)
-SSH_KEY_FILE=&quot;${SSH_KEY_DIR}/id_rsa&quot;
-SSH_KNOWNHOSTS=&quot;${SSH_KEY_DIR}/known_hosts&quot;
+SSH_KEY_FILE="${SSH_KEY_DIR}/id_rsa"
+SSH_KNOWNHOSTS="${SSH_KEY_DIR}/known_hosts"
 function cleanup {
-  echo &quot;Performing cleanup&quot;
-  [ ! -d &quot;${SSH_KEY_DIR}&quot; ] || rm -rf &quot;${SSH_KEY_DIR}&quot;
+  echo "Performing cleanup"
+  [ ! -d "${SSH_KEY_DIR}" ] || rm -rf "${SSH_KEY_DIR}"
 }
 trap cleanup EXIT
-echo &quot;-----BEGIN RSA PRIVATE KEY-----&quot; &gt; &quot;${SSH_KEY_FILE}&quot;
-echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed &quot;s/ /\n/g&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-echo &quot;-----END RSA PRIVATE KEY-----&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-chmod 600 &quot;${SSH_KEY_FILE}&quot;
-ssh-keygen -y -f &quot;${SSH_KEY_FILE}&quot; &gt; &quot;${SSH_KEY_DIR}/id_rsa.pub&quot;
+echo "-----BEGIN RSA PRIVATE KEY-----" &gt; "${SSH_KEY_FILE}"
+echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed "s/ /\n/g" &gt;&gt; "${SSH_KEY_FILE}"
+echo "-----END RSA PRIVATE KEY-----" &gt;&gt; "${SSH_KEY_FILE}"
+chmod 600 "${SSH_KEY_FILE}"
+ssh-keygen -y -f "${SSH_KEY_FILE}" &gt; "${SSH_KEY_DIR}/id_rsa.pub"
 
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
-  echo &quot;Pulling latest calyptos docker image&quot;
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
+  echo "Pulling latest calyptos docker image"
   docker pull sjones4/calyptos:4.4
 fi
 
-echo &quot;Host status before release&quot;
+echo "Host status before release"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-status.sh
 
-echo &quot;Releasing hosts using ${RESERVATION_ID}&quot;
+echo "Releasing hosts using ${RESERVATION_ID}"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-release.sh ${RESERVATION_ID}
 
-echo &quot;Host status after release&quot;
+echo "Host status after release"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-status.sh

--- a/jenkins/eucalyptus-host-reserve/config.xml
+++ b/jenkins/eucalyptus-host-reserve/config.xml
@@ -46,10 +46,10 @@
           <description></description>
           <choices class="java.util.Arrays$ArrayList">
             <a class="string-array">
+              <string>8</string>
               <string>16</string>
               <string>32</string>
               <string>64</string>
-              <string>128</string>
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
@@ -103,7 +103,7 @@ while [ ${HOST_PARAM_CPU} -ge 4 ] ; do
   HOST_PARAM_CPU=$((HOST_PARAM_CPU / 2))
 done
 HOST_PARAMS=&quot;${HOST_PARAMS}:DISKX:MEM&quot;
-while [ ${HOST_PARAM_MEM} -ge 16 ] ; do
+while [ ${HOST_PARAM_MEM} -ge 8 ] ; do
   HOST_PARAMS=&quot;${HOST_PARAMS}X&quot;
   HOST_PARAM_MEM=$((HOST_PARAM_MEM / 2))
 done

--- a/jenkins/eucalyptus-host-reset/config.xml
+++ b/jenkins/eucalyptus-host-reset/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,14 +19,14 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus-extras/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>HOSTS_TO_RESET</name>
           <description>Space separated list of hosts to reset. WARNING, this does not check reservations.</description>
-          <defaultValue></defaultValue>
+          <defaultValue/>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -44,7 +43,7 @@
       <project>eucalyptus-host-config</project>
       <filter>hosts.txt</filter>
       <target>hosts</target>
-      <excludes></excludes>
+      <excludes/>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
         <stable>true</stable>
       </selector>
@@ -54,39 +53,39 @@
     <hudson.tasks.Shell>
       <command># ssh key setup
 SSH_KEY_DIR=$(mktemp -dt ssh.XXXXXXXX)
-SSH_KEY_FILE=&quot;${SSH_KEY_DIR}/id_rsa&quot;
-SSH_KNOWNHOSTS=&quot;${SSH_KEY_DIR}/known_hosts&quot;
+SSH_KEY_FILE="${SSH_KEY_DIR}/id_rsa"
+SSH_KNOWNHOSTS="${SSH_KEY_DIR}/known_hosts"
 function cleanup {
-  echo &quot;Performing cleanup&quot;
-  [ ! -d &quot;${SSH_KEY_DIR}&quot; ] || rm -rf &quot;${SSH_KEY_DIR}&quot;
+  echo "Performing cleanup"
+  [ ! -d "${SSH_KEY_DIR}" ] || rm -rf "${SSH_KEY_DIR}"
 }
 trap cleanup EXIT
-echo &quot;-----BEGIN RSA PRIVATE KEY-----&quot; &gt; &quot;${SSH_KEY_FILE}&quot;
-echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed &quot;s/ /\n/g&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-echo &quot;-----END RSA PRIVATE KEY-----&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-chmod 600 &quot;${SSH_KEY_FILE}&quot;
-ssh-keygen -y -f &quot;${SSH_KEY_FILE}&quot; &gt; &quot;${SSH_KEY_DIR}/id_rsa.pub&quot;
+echo "-----BEGIN RSA PRIVATE KEY-----" &gt; "${SSH_KEY_FILE}"
+echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed "s/ /\n/g" &gt;&gt; "${SSH_KEY_FILE}"
+echo "-----END RSA PRIVATE KEY-----" &gt;&gt; "${SSH_KEY_FILE}"
+chmod 600 "${SSH_KEY_FILE}"
+ssh-keygen -y -f "${SSH_KEY_FILE}" &gt; "${SSH_KEY_DIR}/id_rsa.pub"
 
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
-  echo &quot;Pulling latest calyptos docker image&quot;
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
+  echo "Pulling latest calyptos docker image"
   docker pull sjones4/calyptos:4.4
 fi
 
-echo &quot;Host status before reset&quot;
+echo "Host status before reset"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-status.sh
 
-echo &quot;Releasing hosts using ${HOSTS_TO_RESET}&quot;
+echo "Releasing hosts using ${HOSTS_TO_RESET}"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   sjones4/calyptos:4.4 host-free.sh --initialize ${HOSTS_TO_RESET}
 
-echo &quot;Host status after reset&quot;
+echo "Host status after reset"
 docker run --rm \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-status.sh

--- a/jenkins/eucalyptus-host-status/config.xml
+++ b/jenkins/eucalyptus-host-status/config.xml
@@ -1,14 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.plugins.buildblocker.BuildBlockerProperty plugin="build-blocker-plugin@1.7.3">
       <useBuildBlocker>false</useBuildBlocker>
       <blockLevel>GLOBAL</blockLevel>
       <scanQueueFor>DISABLED</scanQueueFor>
-      <blockingJobs></blockingJobs>
+      <blockingJobs/>
     </hudson.plugins.buildblocker.BuildBlockerProperty>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
@@ -20,7 +19,7 @@
     </jenkins.model.BuildDiscarderProperty>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.28.1">
       <projectUrl>https://github.com/sjones4/eucalyptus-extras/</projectUrl>
-      <displayName></displayName>
+      <displayName/>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
@@ -35,7 +34,7 @@
       <project>eucalyptus-host-config</project>
       <filter>hosts.txt</filter>
       <target>hosts</target>
-      <excludes></excludes>
+      <excludes/>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector">
         <stable>true</stable>
       </selector>
@@ -48,28 +47,28 @@
 
 # ssh key setup
 SSH_KEY_DIR=$(mktemp -dt ssh.XXXXXXXX)
-SSH_KEY_FILE=&quot;${SSH_KEY_DIR}/id_rsa&quot;
-SSH_KNOWNHOSTS=&quot;${SSH_KEY_DIR}/known_hosts&quot;
+SSH_KEY_FILE="${SSH_KEY_DIR}/id_rsa"
+SSH_KNOWNHOSTS="${SSH_KEY_DIR}/known_hosts"
 function cleanup {
-  echo &quot;Performing cleanup&quot;
-  [ ! -d &quot;${SSH_KEY_DIR}&quot; ] || rm -rf &quot;${SSH_KEY_DIR}&quot;
+  echo "Performing cleanup"
+  [ ! -d "${SSH_KEY_DIR}" ] || rm -rf "${SSH_KEY_DIR}"
 }
 trap cleanup EXIT
-echo &quot;-----BEGIN RSA PRIVATE KEY-----&quot; &gt; &quot;${SSH_KEY_FILE}&quot;
-echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed &quot;s/ /\n/g&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-echo &quot;-----END RSA PRIVATE KEY-----&quot; &gt;&gt; &quot;${SSH_KEY_FILE}&quot;
-chmod 600 &quot;${SSH_KEY_FILE}&quot;
-ssh-keygen -y -f &quot;${SSH_KEY_FILE}&quot; &gt; &quot;${SSH_KEY_DIR}/id_rsa.pub&quot;
+echo "-----BEGIN RSA PRIVATE KEY-----" &gt; "${SSH_KEY_FILE}"
+echo ${EUCALYPTUS_GLOBAL_SSH_KEY} | sed "s/ /\n/g" &gt;&gt; "${SSH_KEY_FILE}"
+echo "-----END RSA PRIVATE KEY-----" &gt;&gt; "${SSH_KEY_FILE}"
+chmod 600 "${SSH_KEY_FILE}"
+ssh-keygen -y -f "${SSH_KEY_FILE}" &gt; "${SSH_KEY_DIR}/id_rsa.pub"
 
-if [ &quot;true&quot; = &quot;${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}&quot; ] ; then
-  echo &quot;Pulling latest calyptos docker image&quot;
+if [ "true" = "${EUCALYPTUS_GLOBAL_DOCKER_PULLS:-true}" ] ; then
+  echo "Pulling latest calyptos docker image"
   docker pull sjones4/calyptos:4.4
 fi
 
-echo &quot;Host status&quot;
+echo "Host status"
 docker run --rm \
-  -e SSH_OPTS=&apos;-o ConnectTimeout=5 -o ConnectionAttempts=1&apos; \
-  -v &quot;${SSH_KEY_DIR}&quot;:/root/.ssh \
+  -e SSH_OPTS='-o ConnectTimeout=5 -o ConnectionAttempts=1' \
+  -v "${SSH_KEY_DIR}":/root/.ssh \
   -v $(pwd)/hosts:/calyptos/hosts \
   -w /calyptos/hosts \
   sjones4/calyptos:4.4 host-status.sh | tee hosts/status.txt

--- a/jenkins/jobs-get.sh
+++ b/jenkins/jobs-get.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Get current job configuration from jenkins via cli
+set -euo pipefail
+
+JENKINS_SERVER="${1:-}"
+JENKINS_OPTS=${JENKINS_OPTS:-}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${JENKINS_SERVER}" ] ; then
+  echo "Usage: ${0} JENKINS_URI" >&2
+  exit 1
+fi
+
+JENKINS_JAR_TEMP=$(mktemp -t jenkins-cli.jar.XXXXXXXX)
+function cleanup {
+  [ ! -f "${JENKINS_JAR_TEMP}" ] || rm -f "${JENKINS_JAR_TEMP}"
+}
+trap cleanup EXIT
+
+echo "Downloading CLI JAR"
+curl --insecure \
+  --output "${JENKINS_JAR_TEMP}" \
+  "${JENKINS_SERVER}/jnlpJars/jenkins-cli.jar"
+
+for JOB_CONFIG in ${SCRIPT_DIR}/*/config.xml; do
+  JOB_NAME="${JOB_CONFIG##${SCRIPT_DIR}/}"
+  JOB_NAME="${JOB_NAME%%/config.xml}"
+  java -jar "${JENKINS_JAR_TEMP}" \
+    ${JENKINS_OPTS} \
+    -s "${JENKINS_SERVER}" \
+    get-job \
+    ${JOB_NAME} > "${JOB_CONFIG}" || true
+done

--- a/jenkins/jobs-update.sh
+++ b/jenkins/jobs-update.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Update jobs on jenkins via cli
+set -euo pipefail
+
+JENKINS_SERVER="${1:-}"
+JENKINS_OPTS=${JENKINS_OPTS:-}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${JENKINS_SERVER}" ] ; then
+  echo "Usage: ${0} JENKINS_URI" >&2
+  exit 1
+fi
+
+JENKINS_JAR_TEMP=$(mktemp -t jenkins-cli.jar.XXXXXXXX)
+function cleanup {
+  [ ! -f "${JENKINS_JAR_TEMP}" ] || rm -f "${JENKINS_JAR_TEMP}"
+}
+trap cleanup EXIT
+
+echo "Downloading CLI JAR"
+curl --insecure \
+  --output "${JENKINS_JAR_TEMP}" \
+  "${JENKINS_SERVER}/jnlpJars/jenkins-cli.jar"
+
+for JOB_CONFIG in ${SCRIPT_DIR}/*/config.xml; do
+  JOB_NAME="${JOB_CONFIG##${SCRIPT_DIR}/}"
+  JOB_NAME="${JOB_NAME%%/config.xml}"
+  java -jar "${JENKINS_JAR_TEMP}" \
+    ${JENKINS_OPTS} \
+    -s "${JENKINS_SERVER}" \
+    update-job \
+    ${JOB_NAME} < "${JOB_CONFIG}"
+done
+


### PR DESCRIPTION
Add a template for ceph deployment support. A new job is added for yaml aliases that can be used in any template. This is useful for structured global configuration as used with ceph and settings that are similar in every template.