### PR TITLE
Deployment template cleanup, add ceph multicluster template

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 RUN yum -y install epel-release \
- && yum -y install gcc make patch git python-devel python2-pip libffi-devel openssl-devel libyaml-devel \
+ && yum -y install gcc git libffi-devel libyaml-devel make openssl-devel patch python2-pip python-devel \
  && pip install --upgrade pip setuptools \
  && easy_install pbr \
  && yum -y install https://packages.chef.io/files/stable/chefdk/0.12.0/el/7/chefdk-0.12.0-1.el7.x86_64.rpm \

--- a/deploy/templates/cloud-in-a-box-das-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-das-environment.yaml
@@ -29,17 +29,14 @@ default_attributes:
             mode: EDGE
             InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
             PublicIps: [ETP_PUBLIC_IP_RANGE]
-            clusters:
-                - Name: one
-                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
-                  Subnet:
-                      Subnet: ETP_SUBNET
-                      Name: ETP_SUBNET
-                      Netmask: ETP_NETMASK
-                      Gateway: ETP_GATEWAY
+            PrivateIps: [ETP_PRIVATE_IP_RANGE]
+            subnets:
+                - Subnet: ETP_SUBNET
+                  Netmask: ETP_NETMASK
+                  Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}

--- a/deploy/templates/cloud-in-a-box-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-environment.yaml
@@ -37,8 +37,8 @@ default_attributes:
                       Netmask: ETP_NETMASK
                       Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}

--- a/deploy/templates/cloud-in-a-box-with-console-environment.yaml
+++ b/deploy/templates/cloud-in-a-box-with-console-environment.yaml
@@ -38,8 +38,8 @@ default_attributes:
                       Netmask: ETP_NETMASK
                       Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}

--- a/deploy/templates/edge-ceph-multicluster-environment.yaml
+++ b/deploy/templates/edge-ceph-multicluster-environment.yaml
@@ -1,6 +1,6 @@
 ---
-name: edge-ceph
-description: 'Eucalyptus cloud with edge networking and ceph'
+name: edge-ceph-multicluster
+description: 'Eucalyptus cloud with edge networking and ceph 2 clusters'
 template_aliases: ETP_TEMPLATE_ALIASES
 default_attributes:
     eucalyptus:
@@ -29,29 +29,31 @@ default_attributes:
                 secret-key: ETP_CEPH_S3_SECRET_KEY
                 ceph-radosgw:
                     endpoint: ETP_CEPH_S3_ENDPOINT
-            user-facing: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            user-facing: [ETP_HOST1_IP,ETP_HOST2_IP]  # ETP_HOST1_NAME ETP_HOST2_NAME
             clusters:
                 one:
                     storage-backend: ceph-rbd
-                    cc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
-                    sc: [ETP_HOST0_IP]  # ETP_HOST0_NAME
-                    nodes: [ETP_HOST1_IP]  # ETP_HOST1_NAME
+                    cc: [ETP_HOST1_IP]  # ETP_HOST1_NAME
+                    sc: [ETP_HOST1_IP]  # ETP_HOST1_NAME
+                    nodes: [ETP_HOST3_IP]  # ETP_HOST3_NAME
+                two:
+                    storage-backend: ceph-rbd
+                    cc: [ETP_HOST2_IP]  # ETP_HOST2_NAME
+                    sc: [ETP_HOST2_IP]  # ETP_HOST2_NAME
+                    nodes: [ETP_HOST4_IP]  # ETP_HOST4_NAME
         cc:
             <<: *alias_eucalyptus_cc
         nc:
             <<: *alias_eucalyptus_nc
         network:
             mode: EDGE
-            InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
+            InstanceDnsServers: [ETP_HOST1_IP,ETP_HOST2_IP]  # ETP_HOST1_NAME ETP_HOST2_NAME
             PublicIps: [ETP_PUBLIC_IP_RANGE]
-            clusters:
-                - Name: one
-                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
-                  Subnet:
-                      Subnet: ETP_SUBNET
-                      Name: ETP_SUBNET
-                      Netmask: ETP_NETMASK
-                      Gateway: ETP_GATEWAY
+            PrivateIps: [ETP_PRIVATE_IP_RANGE]
+            subnets:
+                - Subnet: ETP_SUBNET
+                  Netmask: ETP_NETMASK
+                  Gateway: ETP_GATEWAY
             bridge-interface: br0
             public-interface: ETP_NODE_NIC
             private-interface: ETP_NODE_NIC

--- a/deploy/templates/edge-environment.yaml
+++ b/deploy/templates/edge-environment.yaml
@@ -29,17 +29,14 @@ default_attributes:
             mode: EDGE
             InstanceDnsServers: [ETP_HOST0_IP]  # ETP_HOST0_NAME
             PublicIps: [ETP_PUBLIC_IP_RANGE]
-            clusters:
-                - Name: one
-                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
-                  Subnet:
-                      Subnet: ETP_SUBNET
-                      Name: ETP_SUBNET
-                      Netmask: ETP_NETMASK
-                      Gateway: ETP_GATEWAY
+            PrivateIps: [ETP_PRIVATE_IP_RANGE]
+            subnets:
+                - Subnet: ETP_SUBNET
+                  Netmask: ETP_NETMASK
+                  Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}

--- a/deploy/templates/edge-multicluster-multinode-environment.yaml
+++ b/deploy/templates/edge-multicluster-multinode-environment.yaml
@@ -34,17 +34,14 @@ default_attributes:
             mode: EDGE
             InstanceDnsServers: [ETP_HOST1_IP, ETP_HOST2_IP]  # ETP_HOST1_NAME ETP_HOST2_NAME
             PublicIps: [ETP_PUBLIC_IP_RANGE]
-            clusters:
-                - Name: one
-                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
-                  Subnet:
-                      Subnet: ETP_SUBNET
-                      Name: ETP_SUBNET
-                      Netmask: ETP_NETMASK
-                      Gateway: ETP_GATEWAY
+            PrivateIps: [ETP_PRIVATE_IP_RANGE]
+            subnets:
+                - Subnet: ETP_SUBNET
+                  Netmask: ETP_NETMASK
+                  Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}

--- a/deploy/templates/edge-multinode-environment.yaml
+++ b/deploy/templates/edge-multinode-environment.yaml
@@ -28,17 +28,14 @@ default_attributes:
             mode: EDGE
             InstanceDnsServers: [ETP_HOST1_IP]  # ETP_HOST1_NAME
             PublicIps: [ETP_PUBLIC_IP_RANGE]
-            clusters:
-                - Name: one
-                  PrivateIps: [ETP_PRIVATE_IP_RANGE]
-                  Subnet:
-                      Subnet: ETP_SUBNET
-                      Name: ETP_SUBNET
-                      Netmask: ETP_NETMASK
-                      Gateway: ETP_GATEWAY
+            PrivateIps: [ETP_PRIVATE_IP_RANGE]
+            subnets:
+                - Subnet: ETP_SUBNET
+                  Netmask: ETP_NETMASK
+                  Gateway: ETP_GATEWAY
             bridge-interface: br0
-            public-interface: br0
-            private-interface: br0
+            public-interface: ETP_NODE_NIC
+            private-interface: ETP_NODE_NIC
             bridged-nic: ETP_NODE_NIC
             dns-server: ETP_DNS_SERVER
 override_attributes: {}


### PR DESCRIPTION
Update deployment templates for sjones4/eucalyptus-cookbook/pull/4 which allows clusters to be omitted from the network configuration. Switch templates to use the bridged nic rather than the bridge for the public/private network interface.