### PR TITLE
Docker build image use 7.3 base

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:7.3.1611
 
 ADD [ "build-*.sh", "rpm-*.sh", "/root/bin/" ]
 


### PR DESCRIPTION
Switch docker build image to use CentOS 7.3.1611 for the base.