### PR TITLE
Docker minio client with instance profile support enabled

### DIFF
--- a/docker/minio-client/Dockerfile
+++ b/docker/minio-client/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache curl
+
+ENV PATH=/root/bin:$PATH
+
+ADD [ "mc", "/root/bin/" ]
+
+RUN chown --recursive root:root /root/bin/* \
+ && chmod 755 /root/bin/*
+


### PR DESCRIPTION
Dockerfile for building an alpine linux minio client (mc) supporting instance profiles as configured by host.

Minio client changes: sjones4/mc@6ba81e17af4df337b3cf1e85775d5929375e9954