### PR TITLE
Docker cf templates for appscale image / bootstrap

### DIFF
--- a/docker/eucalyptus-templates/templates/appscale-bootstrap-template.json
+++ b/docker/eucalyptus-templates/templates/appscale-bootstrap-template.json
@@ -1,0 +1,244 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Appscale bootstrap template",
+
+  "Parameters" : {
+
+    "AppScaleRepo" : {
+      "Description" : "AppScale git repository",
+      "Type" : "String",
+      "Default" : "git://github.com/AppScale/appscale.git"
+    },
+
+    "AppScaleBranch" : {
+      "Description" : "AppScale git repository branch",
+      "Type" : "String",
+      "Default" : "master"
+    },
+
+    "AppScaleToolsRepo" : {
+      "Description" : "AppScale tools git repository",
+      "Type" : "String",
+      "Default" : "git://github.com/AppScale/appscale-tools.git"
+    },
+
+    "AppScaleToolsBranch" : {
+      "Description" : "AppScale tools git repository branch",
+      "Type" : "String",
+      "Default" : "master"
+    },
+
+    "AdminUserEmail" : {
+      "Description" : "AppScale admin user",
+      "Type" : "String",
+      "Default" : "a@a.com"
+    },
+
+    "AdminUserPassword" : {
+      "Description" : "AppScale admin password",
+      "Type" : "String",
+      "Default" : "password"
+    },
+
+    "InstanceHttpProxy" : {
+      "Description" : "Instance http proxy (http://host:port/)",
+      "Type" : "String",
+      "Default" : ""
+    },
+
+    "InstanceType" : {
+      "Description" : "Instance type to use",
+      "Type" : "String",
+      "Default" : "m3.medium"
+    },
+
+    "ImageId": {
+      "Description" : "Identifier for the base ubuntu xenial image",
+      "Type": "String"
+    },
+
+    "KeyName": {
+      "Description" : "EC2 keypair for instance SSH access",
+      "Type": "String"
+    },
+
+    "Zone": {
+      "Description" : "Availability zone to use",
+      "Type": "String",
+      "Default": "auto-select"
+    }
+
+  },
+
+  "Conditions" : {
+    "UseZoneParameter" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "Zone"}, "auto-select"]}]},
+    "UseHttpProxy" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "InstanceHttpProxy"}, ""]}]}
+  },
+
+  "Resources" : {
+
+    "WaitConditionHandle" : {
+      "Type" : "AWS::CloudFormation::WaitConditionHandle"
+    },
+
+    "WaitCondition" : {
+      "Type" : "AWS::CloudFormation::WaitCondition",
+      "Properties" : {
+        "Handle" : { "Ref" : "WaitConditionHandle" },
+        "Timeout" : "3600"
+      }
+    },
+
+    "SecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "appscale security group",
+        "SecurityGroupIngress" : [
+          {"IpProtocol" : "tcp", "FromPort" : "1", "ToPort" : "65535", "CidrIp" : "0.0.0.0/0"}
+        ]
+      }
+    },
+
+    "Instance" : {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] },
+        "ImageId"        : { "Ref" : "ImageId" },
+        "InstanceType"   : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ {"Ref" : "SecurityGroup"} ],
+        "KeyName"        : { "Ref" : "KeyName" },
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+          "#cloud-config\n",
+          "write_files:\n",
+          { "Fn::If" : [
+            "UseHttpProxy",
+            { "Fn::Join" : ["", [
+		      "  - path: /etc/apt/apt.conf.d/02proxy\n",
+		      "    permissions: \"0644\"\n",
+		      "    owner: root\n",
+		      "    content: |\n",
+              "     Acquire::http::Proxy \"", { "Ref" : "InstanceHttpProxy" },"\";\n"
+            ]] },
+            ""
+          ] },
+          "  - path: /root/AppScalefile\n",
+          "    permissions: \"0600\"\n",
+          "    owner: root\n",
+          "    content: |\n",
+          "     ---\n",
+          "     login      : PUBLIC_IP_HERE\n",
+          "     ips_layout :\n",
+          "       -\n",
+          "         roles:\n",
+          "           - master\n",
+          "           - compute\n",
+          "           - database\n",
+          "           - zookeeper\n",
+          "         nodes: PRIVATE_IP_HERE\n",
+          "     admin_user : ", { "Ref" : "AdminUserEmail" } ,"\n",
+          "     admin_pass : ", { "Ref" : "AdminUserPassword" } ,"\n",
+          "     group      : ", { "Fn::GetAtt" : [ "SecurityGroup", "GroupId" ] }, "\n",
+          "  - path: /root/cloud-bootstrap.sh\n",
+          "    permissions: \"0700\"\n",
+          "    owner: root\n",
+          "    content: |\n",
+          "     #!/bin/bash\n",
+          "     set -euxo pipefail\n",
+          "\n",
+          "     HTTPPROXY=\"", { "Ref" : "InstanceHttpProxy" }, "\"\n",
+          "     WAITCONDURL=\"", { "Ref" : "WaitConditionHandle" }, "\"\n",
+          "     COND_DATA='init'\n",
+          "     COND_REASON='AppScale not up'\n",
+          "\n",
+          "     function cleanup {\n",
+          "       # Signal cloudformation wait condition handle\n",
+          "       curl -s -X PUT -H 'Content-Type:' \\\n",
+          "         --data-binary '{\"Status\": \"SUCCESS\", \"UniqueId\": \"bootstrap\", \"Data\": \"'\"${COND_DATA}\"'\", \"Reason\": \"'\"${COND_REASON}\"'\" }' \\\n",
+          "         ${WAITCONDURL}\n",
+          "     }\n",
+          "     trap cleanup EXIT\n",
+          "\n",
+          "     # Configure ips\n",
+          "     COND_DATA='configure ips'\n",
+          "     PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)\n",
+          "     PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)\n",
+          "     sed --in-place \"s/PRIVATE_IP_HERE/${PRIVATE_IP}/\" /root/AppScalefile\n",
+          "     sed --in-place \"s/PUBLIC_IP_HERE/${PUBLIC_IP}/\" /root/AppScalefile\n",
+          "\n",
+          "     # Configure ssh for root\n",
+          "     COND_DATA='configure ssh'\n",
+          "     export HOME=/root\n",
+          "     mkdir -pv \"${HOME}/.ssh\" || true\n",
+          "     chmod 700 \"${HOME}/.ssh\"\n",
+          "     test -e \"${HOME}/.ssh/id_rsa.pub\" || ssh-keygen -q -t rsa -f \"${HOME}/.ssh/id_rsa\" -N \"\"\n",
+          "     cat \"${HOME}/.ssh/id_rsa.pub\" >> \"${HOME}/.ssh/authorized_keys\"\n",
+          "     chmod 600 \"${HOME}/.ssh/authorized_keys\"\n",
+          "     if [ -e \"${HOME}/.ssh/known_hosts\" ]; then\n",
+          "       ssh-keygen -R ${PUBLIC_IP}\n",
+          "       ssh-keygen -R ${PRIVATE_IP}\n",
+          "     fi\n",
+          "     ssh-keyscan ${PUBLIC_IP} ${PRIVATE_IP} 2> /dev/null >> \"${HOME}/.ssh/known_hosts\"\n",
+          "\n",
+          "     # Bootstrap appscale\n",
+          "     COND_DATA='configure bootstrap'\n",
+          "     cd /root\n",
+          "     apt-get update\n",
+          "     wget -O bootstrap.sh https://bootstrap.appscale.com\n",
+          "     COND_DATA='run bootstrap'\n",
+          "     [ -z \"${HTTPPROXY}\" ] || export http_proxy=${HTTPPROXY}\n",
+          "     bash bootstrap.sh \\\n",
+          "       --repo         ", { "Ref" : "AppScaleRepo" }, "\\\n",
+          "       --branch       ", { "Ref" : "AppScaleBranch" }, "\\\n",
+          "       --tools-repo   ", { "Ref" : "AppScaleToolsRepo" }, "\\\n",
+          "       --tools-branch ", { "Ref" : "AppScaleToolsBranch" }, "\n",
+          "\n",
+          "     # Start appscale\n",
+          "     COND_DATA='run appscale up'\n",
+          "     appscale up\n",
+          "     COND_DATA='complete'\n",
+          "     COND_REASON='AppScale up'\n",
+          "\n",
+          "runcmd:\n",
+          " - /root/cloud-bootstrap.sh\n",
+          "\n"
+        ]]}}
+      }
+    }
+
+  },
+
+  "Outputs" : {
+
+    "BootstrapStatus" : {
+      "Description" : "AppScale bootstrap/up status",
+      "Value" : { "Fn::GetAtt" : [ "WaitCondition", "Data" ]}
+    },
+
+    "InstanceId" : {
+      "Description" : "Appscale instance",
+      "Value" : { "Ref" : "Instance" }
+    },
+
+    "Ip" : {
+      "Description" : "Appscale instance ip",
+      "Value" : { "Fn::GetAtt" : [ "Instance", "PublicIp"] }
+    },
+
+    "Hostname" : {
+      "Description" : "Appscale instance host",
+      "Value" : { "Fn::GetAtt" : [ "Instance", "PublicDnsName"] }
+    },
+
+    "Dashboard" : {
+      "Description" : "AppScale dashboard url",
+      "Value" : { "Fn::Join" : ["", ["https://", { "Fn::GetAtt" : [ "Instance", "PublicDnsName"] }, ":1443/"]] }
+    }
+
+  }
+}
+

--- a/docker/eucalyptus-templates/templates/appscale-template.json
+++ b/docker/eucalyptus-templates/templates/appscale-template.json
@@ -1,0 +1,173 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Appscale single node template",
+
+  "Parameters" : {
+
+    "AdminUserEmail" : {
+      "Description" : "AppScale admin user",
+      "Type" : "String",
+      "Default" : "a@a.com"
+    },
+
+    "AdminUserPassword" : {
+      "Description" : "AppScale admin password",
+      "Type" : "String",
+      "Default" : "password"
+    },
+
+    "InstanceType" : {
+      "Description" : "Instance type to use",
+      "Type" : "String",
+      "Default" : "m3.medium"
+    },
+
+    "ImageId": {
+      "Description" : "Identifier for the appscale image",
+      "Type": "String"
+    },
+
+    "KeyName": {
+      "Description" : "EC2 keypair for instance SSH access",
+      "Type": "String"
+    },
+
+    "Zone": {
+      "Description" : "Availability zone to use",
+      "Type": "String",
+      "Default": "auto-select"
+    }
+
+  },
+
+  "Conditions" : {
+    "UseZoneParameter" : {"Fn::Not": [{"Fn::Equals" : [{"Ref" : "Zone"}, "auto-select"]}]}
+  },
+
+  "Resources" : {
+
+    "WaitConditionHandle" : {
+      "Type" : "AWS::CloudFormation::WaitConditionHandle"
+    },
+
+    "WaitCondition" : {
+      "Type" : "AWS::CloudFormation::WaitCondition",
+      "Properties" : {
+        "Handle" : { "Ref" : "WaitConditionHandle" },
+        "Timeout" : "900"
+      }
+    },
+
+    "SecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "appscale security group",
+        "SecurityGroupIngress" : [
+          {"IpProtocol" : "tcp", "FromPort" : "1", "ToPort" : "65535", "CidrIp" : "0.0.0.0/0"}
+        ]
+      }
+    },
+
+    "Instance" : {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "AvailabilityZone": { "Fn::If" : [
+          "UseZoneParameter",
+          { "Ref" : "Zone" },
+          { "Fn::Select" : [ "0", { "Fn::GetAZs" : { "Ref" : "AWS::Region" } } ] }
+        ] },
+        "ImageId"        : { "Ref" : "ImageId" },
+        "InstanceType"   : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ {"Ref" : "SecurityGroup"} ],
+        "KeyName"        : { "Ref" : "KeyName" },
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+          "#cloud-config\n",
+          "write_files:\n",
+          "  - path: /root/AppScalefile\n",
+          "    permissions: \"0600\"\n",
+          "    owner: root\n",
+          "    content: |\n",
+          "     ---\n",
+          "     login      : PUBLIC_IP_HERE\n",
+          "     ips_layout :\n",
+          "       -\n",
+          "         roles:\n",
+          "           - master\n",
+          "           - compute\n",
+          "           - database\n",
+          "           - zookeeper\n",
+          "         nodes: PRIVATE_IP_HERE\n",
+          "     admin_user : ", { "Ref" : "AdminUserEmail" } ,"\n",
+          "     admin_pass : ", { "Ref" : "AdminUserPassword" } ,"\n",
+          "     group      : ", { "Fn::GetAtt" : [ "SecurityGroup", "GroupId" ] }, "\n",
+          "  - path: /root/cloud-start.sh\n",
+          "    permissions: \"0700\"\n",
+          "    owner: root\n",
+          "    content: |\n",
+          "     #!/bin/bash\n",
+          "     set -euxo pipefail\n",
+          "\n",
+          "     WAITCONDURL=\"", { "Ref" : "WaitConditionHandle" }, "\"\n",
+          "\n",
+          "     # Configure ips\n",
+          "     PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)\n",
+          "     PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)\n",
+          "     sed --in-place \"s/PRIVATE_IP_HERE/${PRIVATE_IP}/\" /root/AppScalefile\n",
+          "     sed --in-place \"s/PUBLIC_IP_HERE/${PUBLIC_IP}/\" /root/AppScalefile\n",
+          "\n",
+          "     # Configure ssh for root\n",
+          "     export HOME=/root\n",
+          "     mkdir -pv \"${HOME}/.ssh\" || true\n",
+          "     chmod 700 \"${HOME}/.ssh\"\n",
+          "     test -e \"${HOME}/.ssh/id_rsa.pub\" || ssh-keygen -q -t rsa -f \"${HOME}/.ssh/id_rsa\" -N \"\"\n",
+          "     cat \"${HOME}/.ssh/id_rsa.pub\" >> \"${HOME}/.ssh/authorized_keys\"\n",
+          "     chmod 600 \"${HOME}/.ssh/authorized_keys\"\n",
+          "     if [ -e \"${HOME}/.ssh/known_hosts\" ]; then\n",
+          "       ssh-keygen -R ${PUBLIC_IP}\n",
+          "       ssh-keygen -R ${PRIVATE_IP}\n",
+          "     fi\n",
+          "     ssh-keyscan ${PUBLIC_IP} ${PRIVATE_IP} 2> /dev/null >> \"${HOME}/.ssh/known_hosts\"\n",
+          "\n",
+          "     # Start appscale\n",
+          "     cd /root\n",
+          "     appscale up\n",
+          "\n",
+          "     # Signal cloudformation wait condition handle\n",
+          "     curl -s -X PUT -H 'Content-Type:' \\\n",
+          "       --data-binary '{\"Status\": \"SUCCESS\", \"UniqueId\": \"up\", \"Data\": \"-\", \"Reason\": \"AppScale up\" }' \\\n",
+          "       ${WAITCONDURL}\n",
+          "runcmd:\n",
+          " - /root/cloud-start.sh\n",
+          "\n"
+        ]]}}
+      }
+    }
+
+  },
+
+  "Outputs" : {
+
+    "InstanceId" : {
+      "Description" : "Appscale instance",
+      "Value" : { "Ref" : "Instance" }
+    },
+
+    "Ip" : {
+      "Description" : "Appscale instance ip",
+      "Value" : { "Fn::GetAtt" : [ "Instance", "PublicIp"] }
+    },
+
+    "Hostname" : {
+      "Description" : "Appscale instance host",
+      "Value" : { "Fn::GetAtt" : [ "Instance", "PublicDnsName"] }
+    },
+
+    "Dashboard" : {
+      "Description" : "AppScale dashboard url",
+      "Value" : { "Fn::Join" : ["", ["https://", { "Fn::GetAtt" : [ "Instance", "PublicDnsName"] }, ":1443/"]] }
+    }
+
+  }
+}
+


### PR DESCRIPTION
Add cloudformation templates to the docker image for single host appscale deployments using an appscale image or an ubuntu xenial image via bootstrap.