### PR TITLE
Image catalog update for Fedora 28

### DIFF
--- a/images/image-catalog.json
+++ b/images/image-catalog.json
@@ -28,22 +28,22 @@
       "image-format": "qcow2"
     },
     {
-      "description": "Fedora Atomic Host 27",
+      "description": "Fedora Atomic Host 28",
       "login": "fedora",
       "url": "https://getfedora.org/atomic_raw_latest",
       "url-name": "https://getfedora.org/atomic_raw_latest_filename",
       "updates": "no",
       "architecture": "x86_64",
-      "os": "fedora-atomic-27",
+      "os": "fedora-atomic-28",
       "image-format": "raw"
     },
     {
-      "description": "Fedora 27",
+      "description": "Fedora 28",
       "login": "fedora",
-      "url": "https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.raw.xz",
+      "url": "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.raw.xz",
       "updates": "no",
       "architecture": "x86_64",
-      "os": "fedora-27",
+      "os": "fedora-28",
       "image-format": "raw"
     },
     {
@@ -83,6 +83,6 @@
       "image-format": "qcow2"
     }
   ],
-  "version": "sjones4-04-20-18"
+  "version": "sjones4-06-20-18"
 }
 


### PR DESCRIPTION
Update image catalog for Fedora 28. The atomic image is always the latest, so for atomic this only fixes the description.