### PR TITLE
Bump chef version, use corymbia/master cookbooks

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -4,21 +4,21 @@ RUN yum -y install epel-release \
  && yum -y install gcc git libffi-devel libyaml-devel make openssl-devel patch python2-pip python-devel \
  && pip install --upgrade pip setuptools \
  && easy_install pbr \
- && yum -y install https://packages.chef.io/files/stable/chefdk/0.12.0/el/7/chefdk-0.12.0-1.el7.x86_64.rpm \
+ && yum -y install https://packages.chef.io/files/stable/chefdk/2.5.3/el/7/chefdk-2.5.3-1.el7.x86_64.rpm \
  && cd /root \
  && git clone --depth 1 https://github.com/sjones4/calyptos \
  && cd calyptos \
  && python setup.py install \
  && mkdir /calyptos \
  && cd /calyptos \
- && git clone --depth 1 --branch devel-4.4 https://github.com/sjones4/eucalyptus-cookbook \
+ && git clone --depth 1 https://github.com/corymbia/eucalyptus-cookbook.git \
+ && sed --in-place '2isolver :ruby' /calyptos/eucalyptus-cookbook/Berksfile \
  && berks install --berksfile /calyptos/eucalyptus-cookbook/Berksfile \
  && rm -rf /root/calyptos /root/.cache \
  && pip uninstall -y setuptools pip \
- && /opt/chefdk/embedded/bin/gem uninstall -a dep_selector \
- && /opt/chefdk/embedded/bin/gem uninstall -a dep-selector-libgecode \
  && yum -y erase gcc keyutils-libs-develkrb5-devel libcom_err-devel libselinux-devel libsepol-devel libverto-devel libyaml-devel make openssl-devel patch python-devel python-setuptools zlib-devel *-headers \
- && yum -y clean all
+ && yum -y clean all \
+ && rm -rf /var/tmp/* /var/cache/yum/*
 
 ENV PATH=/calyptos/bin:$PATH
 

--- a/docker/eucalyptus-cookbook/Dockerfile
+++ b/docker/eucalyptus-cookbook/Dockerfile
@@ -8,11 +8,9 @@ WORKDIR /eucalyptus-cookbook
 # Note that we are installing chefdk 2.5.3 with broken chefinclude
 # support. Once we stop ignoring faststart files we can update to
 # use the latest https://downloads.chef.io/chefdk#el
-#
-# We will use master / corymbia/eucalyptus-cookbook.git at some point
-RUN git clone --depth 1 --branch topic-faststart -- https://github.com/sjones4/eucalyptus-cookbook.git "${EUCALYPTUS_COOKBOOK}" \
+RUN git clone --depth 1 -- https://github.com/corymbia/eucalyptus-cookbook.git "${EUCALYPTUS_COOKBOOK}" \
  && sed --in-place '2isolver :ruby' "${EUCALYPTUS_COOKBOOK}/Berksfile" \
  && berks package -b "${EUCALYPTUS_COOKBOOK}/Berksfile" "${EUCALYPTUS_COOKBOOK_TGZ}" \
- && sed 's/cookbooks_url="\(.*\)"/cookbooks_url="${cookbooks_url:-\1}"/' "${EUCALYPTUS_COOKBOOK}/faststart/cloud-in-a-box.sh" > "cloud-in-a-box.sh" \
+ && cp -fv "${EUCALYPTUS_COOKBOOK}/faststart/cloud-in-a-box.sh" "cloud-in-a-box.sh" \
  && rm -rf "${EUCALYPTUS_COOKBOOK}" /root/.berkshelf
 


### PR DESCRIPTION
Deploy/calyptos updated to use chef dk 2.5.3. Switch to using corymbia/master cookbooks.