### PR TITLE
Builder image service image repo download

### DIFF
--- a/build/build-euca2ools-release-rpm.sh
+++ b/build/build-euca2ools-release-rpm.sh
@@ -17,7 +17,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'euca2ools-release'
+  yum ${YUM_OPTS} erase 'euca2ools-release' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-cloud-libs-rpm.sh
+++ b/build/build-eucalyptus-cloud-libs-rpm.sh
@@ -18,9 +18,9 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
-  yum ${YUM_OPTS} install epel-release # for gengetopt
+  yum ${YUM_OPTS} install epel-release || true # for gengetopt
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-console-rpm.sh
+++ b/build/build-eucalyptus-console-rpm.sh
@@ -41,9 +41,9 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucaconsole-*'
+  yum ${YUM_OPTS} erase 'eucaconsole-*' || true
 
-  yum ${YUM_OPTS} install "epel-release"
+  yum ${YUM_OPTS} install epel-release || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 

--- a/build/build-eucalyptus-console-selinux-rpm.sh
+++ b/build/build-eucalyptus-console-selinux-rpm.sh
@@ -22,7 +22,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucaconsole-*'
+  yum ${YUM_OPTS} erase 'eucaconsole-*' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-release-rpm.sh
+++ b/build/build-eucalyptus-release-rpm.sh
@@ -17,7 +17,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-release'
+  yum ${YUM_OPTS} erase 'eucalyptus-release' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-rpms.sh
+++ b/build/build-eucalyptus-rpms.sh
@@ -52,9 +52,9 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
-  yum ${YUM_OPTS} install epel-release # for gengetopt
+  yum ${YUM_OPTS} install epel-release || true # for gengetopt
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 
@@ -111,7 +111,7 @@ rpmbuild \
     ${RPMBUILD_OPTS} \
     -ba "${RPMBUILD}/SPECS/eucalyptus.spec"
 
-yum ${YUM_OPTS} erase 'eucalyptus-*'
+yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
 find "${RPMBUILD}/SRPMS/"
 

--- a/build/build-eucalyptus-selinux-rpm.sh
+++ b/build/build-eucalyptus-selinux-rpm.sh
@@ -22,7 +22,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-sim-imaging-worker-rpm.sh
+++ b/build/build-eucalyptus-sim-imaging-worker-rpm.sh
@@ -17,7 +17,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-sim-load-balancer-servo-rpm.sh
+++ b/build/build-eucalyptus-sim-load-balancer-servo-rpm.sh
@@ -18,7 +18,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*' 'load-balancer-servo'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' 'load-balancer-servo' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi

--- a/build/build-eucalyptus-sosreport-plugins-rpm.sh
+++ b/build/build-eucalyptus-sosreport-plugins-rpm.sh
@@ -18,7 +18,7 @@ set -ex
 
 # dependencies
 if [ "${MODE}" != "build-only" ] ; then
-  yum ${YUM_OPTS} erase 'eucalyptus-*'
+  yum ${YUM_OPTS} erase 'eucalyptus-*' || true
 
   yum ${YUM_OPTS} install "${REQUIRE[@]}"
 fi


### PR DESCRIPTION
Service image build updated to use `reposync` rather than `yumdownloader` to create the local repository used by the service image kickstart.