### PR TITLE
Ansible playbook use facts for keys

### DIFF
--- a/ansible/roles/cloud/defaults/main.yml
+++ b/ansible/roles/cloud/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # Cloud settings
 cloud_region_region_name: eucalyptus
-cloud_zone_1_name: one
 cloud_listener_cidr: 0.0.0.0/0
 
 # EDGE network settings

--- a/ansible/roles/cloud/tasks/main.yml
+++ b/ansible/roles/cloud/tasks/main.yml
@@ -137,18 +137,6 @@
   until: shell_result.rc == 0
   retries: 5
 
-- name: copy zone keys
-  shell: |
-    CURRENT_HOST="{{ eucalyptus_host_cluster_ipv4 }}"
-    ZONE_HOSTS="{{ groups['zone'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4']) | list | join(' ') }}"
-    for ZONE_HOST in ${ZONE_HOSTS} ; do
-      if [ "${CURRENT_HOST}" = "${ZONE_HOST}" ] ; then
-        cp -f /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/{cluster,node}-{cert,pk}.pem /var/lib/eucalyptus/keys/
-      else
-        clcadmin-copy-keys -z {{ cloud_zone_1_name }} ${ZONE_HOST}
-      fi
-    done
-
 - name: configure cloud properties
   shell: |
     eval $(clcadmin-assume-system-credentials)

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -4,6 +4,7 @@ eucalyptus_yum_baseurl: http://downloads.eucalyptus.cloud/software/eucalyptus/sn
 euca2ools_yum_baseurl: http://downloads.eucalyptus.cloud/software/euca2ools/3.4/rhel/7/x86_64/
 
 # Cloud settings
+cloud_zone_1_name: one
 cloud_opts: "{{cloud_opts_tech_preview}} {{cloud_opts_mem}} {{cloud_opts_custom}} {{cloud_opts_bindaddr}}"
 cloud_opts_custom: ""
 cloud_opts_mem: "-Xmx2g"
@@ -40,3 +41,5 @@ net_public_interface: en1
 net_bridge_interface: "{{ net_mode_[net_mode_lower]['bridge_interface'] }}"
 net_node_router_ip: AUTO
 
+# Role settings
+key_facts: no

--- a/ansible/roles/common/tasks/key_facts.yml
+++ b/ansible/roles/common/tasks/key_facts.yml
@@ -1,0 +1,41 @@
+---
+- name: eucalyptus zone/node keys get cloud-cert
+  slurp:
+    path: /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/cloud-cert.pem
+  register: slurp_result
+
+- name: set eucalyptus zone/node keys cloud-cert fact
+  set_fact: "eucalyptus_keys_{{ cloud_zone_1_name | replace('-','_') }}_cloud_cert='{{ slurp_result.content | b64decode }}'"
+
+- name: eucalyptus zone/node keys get cluster-cert
+  slurp:
+    path: /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/cluster-cert.pem
+  register: slurp_result
+
+- name: set eucalyptus zone/node keys cluster-cert fact
+  set_fact: "eucalyptus_keys_{{ cloud_zone_1_name | replace('-','_') }}_cluster_cert='{{ slurp_result.content | b64decode }}'"
+
+- name: eucalyptus zone/node keys get cluster-pk
+  slurp:
+    path: /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/cluster-pk.pem
+  register: slurp_result
+
+- name: set eucalyptus zone/node keys cluster-pk fact
+  set_fact: "eucalyptus_keys_{{ cloud_zone_1_name | replace('-','_') }}_cluster_pk='{{ slurp_result.content | b64decode }}'"
+
+- name: eucalyptus zone/node keys get node-cert
+  slurp:
+    path: /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/node-cert.pem
+  register: slurp_result
+
+- name: set eucalyptus zone/node keys node-cert fact
+  set_fact: "eucalyptus_keys_{{ cloud_zone_1_name | replace('-','_') }}_node_cert='{{ slurp_result.content | b64decode }}'"
+
+- name: eucalyptus zone/node keys get node-pk
+  slurp:
+    path: /var/lib/eucalyptus/keys/{{ cloud_zone_1_name }}/node-pk.pem
+  register: slurp_result
+
+- name: set eucalyptus zone/node keys node-pk fact
+  set_fact: "eucalyptus_keys_{{ cloud_zone_1_name | replace('-','_') }}_node_pk='{{ slurp_result.content | b64decode }}'"
+

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -14,3 +14,7 @@
 
 - import_tasks: base_config.yml
 
+- import_tasks: key_facts.yml
+  delegate_to: "{{ groups['cloud'][0] }}"
+  run_once: yes
+  when: key_facts

--- a/ansible/roles/node/meta/main.yml
+++ b/ansible/roles/node/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
-  - role: common
+- role: common
+  vars:
+    key_facts: yes

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -75,6 +75,20 @@
     mode: 0644
   when: eucalyptus_ceph_keyring is defined
 
+- name: eucalyptus zone/node keys for node
+  copy:
+    content: "{{ hostvars[inventory_hostname]['eucalyptus_keys_' + (cloud_zone_1_name | replace('-','_')) + '_' + (item | replace('-','_'))] }}"
+    dest: "/var/lib/eucalyptus/keys/{{ item }}.pem"
+    owner: eucalyptus
+    group: eucalyptus
+    mode: 0700
+    force: no
+  loop:
+  - cloud-cert
+  - cluster-cert
+  - node-cert
+  - node-pk
+
 - name: virt remove default network
   virt_net:
     state: absent

--- a/ansible/roles/zone/meta/main.yml
+++ b/ansible/roles/zone/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
-  - role: common
+- role: common
+  vars:
+    key_facts: yes

--- a/ansible/roles/zone/tasks/main.yml
+++ b/ansible/roles/zone/tasks/main.yml
@@ -42,6 +42,21 @@
     mode: 0644
   when: eucalyptus_ceph_keyring is defined
 
+- name: eucalyptus zone/node keys for zone
+  copy:
+    content: "{{ hostvars[inventory_hostname]['eucalyptus_keys_' + (cloud_zone_1_name | replace('-','_')) + '_' + (item | replace('-','_'))] }}"
+    dest: "/var/lib/eucalyptus/keys/{{ item }}.pem"
+    owner: eucalyptus
+    group: eucalyptus
+    mode: 0700
+    force: no
+  loop:
+  - cloud-cert
+  - cluster-cert
+  - cluster-pk
+  - node-cert
+  - node-pk
+
 - name: start tgtd service
   systemd:
     enabled: true
@@ -57,12 +72,6 @@
 
 - name: register node controllers
   shell: |
-    CURRENT_HOST="{{ eucalyptus_host_cluster_ipv4 }}"
     NODE_HOSTS="{{ groups['node'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4']) | list | join(' ') }}"
     clusteradmin-register-nodes ${NODE_HOSTS}
-    for NODE_HOST in ${NODE_HOSTS} ; do
-      if [ "${CURRENT_HOST}" != "${NODE_HOST}" ] ; then
-        clusteradmin-copy-keys ${NODE_HOST}
-      fi
-    done
 


### PR DESCRIPTION
Use ansible facts to share keys between hosts, avoiding the need to configure ssh trust between hosts for copying keys.