### PR TITLE
Ansible playbook add node configuration options

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -31,6 +31,11 @@ cloud_instances_conf_max_cores: "{{ cloud_instances.conf.max_cores }}"
 cloud_instances_conf_max_mem: "{{ cloud_instances.conf.max_mem }}"
 cloud_instances_conf_custom: "{{ cloud_instances.conf.custom }}"
 
+
+# EDGE network settings
+edge_router_enabled: Y
+edge_router_ip: AUTO
+
 # Network settings
 net_mode: EDGE
 net_mode_lower: "{{ net_mode | lower }}"
@@ -42,7 +47,9 @@ net_mode_:
 net_private_interface: "{{ net_public_interface }}"
 net_public_interface: en1
 net_bridge_interface: "{{ net_mode_[net_mode_lower]['bridge_interface'] }}"
-net_node_router_ip: AUTO
+net_node_listen_addr: "{{ eucalyptus_host_cluster_ipv4 }}"
+net_node_router_enabled: "{{ edge_router_enabled }}"
+net_node_router_ip: "{{ edge_router_ip }}"
 
 # Role settings
 key_facts: no

--- a/ansible/roles/common/templates/eucalyptus.conf.j2
+++ b/ansible/roles/common/templates/eucalyptus.conf.j2
@@ -17,5 +17,7 @@ VNET_MODE="{{ net_mode }}"
 VNET_PRIVINTERFACE="{{ net_private_interface }}"
 VNET_PUBINTERFACE="{{ net_public_interface }}"
 VNET_BRIDGE="{{ net_bridge_interface }}"
+NC_ADDR="{{ net_node_listen_addr }}"
+NC_ROUTER="{{ net_node_router_enabled }}"
 NC_ROUTER_IP="{{ net_node_router_ip }}"
 {{ cloud_instances_conf_custom }}


### PR DESCRIPTION
More node configuration options for ansible playbook. By default node controllers will now listen only on the cluster interface.