### PR TITLE
Ansible playbook update generated euca2ools config for n4j test use

### DIFF
--- a/ansible/roles/cloud/tasks/main.yml
+++ b/ansible/roles/cloud/tasks/main.yml
@@ -209,9 +209,9 @@
 - name: generate admin credentials / configuration
   shell: |
     eval $(clcadmin-assume-system-credentials)
-    euare-useraddkey --write-config --domain {{ cloud_system_dns_dnsdomain }} --set-default-user admin > /root/.euca/admin.ini
+    euare-useraddkey --write-config --domain {{ cloud_system_dns_dnsdomain }} --set-default-user admin > /root/.euca/euca-admin.ini
   args:
-    creates: /root/.euca/admin.ini
+    creates: /root/.euca/euca-admin.ini
 
 - name: configure cloud listener address match
   shell: |


### PR DESCRIPTION
Generate euca2ools configuration ini file name as expected by n4j tests.