### PR TITLE
Ansible playbook use enterprise virtualization QEMU from virtualization SIG repo

### DIFF
--- a/ansible/roles/common/tasks/yum_repos.yml
+++ b/ansible/roles/common/tasks/yum_repos.yml
@@ -77,3 +77,13 @@
     state: present
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 
+- name: enable qemu enterprise virtualization yum repository
+  yum:
+    name: centos-release-qemu-ev
+    state: latest
+
+- name: install virtualization sig gpg key
+  rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
+


### PR DESCRIPTION
Configure the QEMU enterprise virtualization yum repository and enable the virtualization sig signing key so the `ev` rpms are installed as dependencies on node controllers.