### PR TITLE
Ansible playbook fix host vars remove duplicate node registration

### DIFF
--- a/ansible/roles/ceph-common/tasks/host_facts.yml
+++ b/ansible/roles/ceph-common/tasks/host_facts.yml
@@ -3,4 +3,3 @@
   set_fact:
     eucalyptus_host_cluster_ipv4: "{{ host_cluster_ipv4 | default(ansible_default_ipv4.address) }}"
     eucalyptus_host_public_ipv4: "{{ host_public_ipv4 | default(ansible_default_ipv4.address) }}"
-  run_once: yes

--- a/ansible/roles/zone/tasks/main.yml
+++ b/ansible/roles/zone/tasks/main.yml
@@ -70,8 +70,3 @@
     state: started
     name: eucalyptus-cloud
 
-- name: register node controllers
-  shell: |
-    NODE_HOSTS="{{ groups['node'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4']) | list | join(' ') }}"
-    clusteradmin-register-nodes ${NODE_HOSTS}
-


### PR DESCRIPTION
Node registration is not required as `eucalyptus.conf` is templated to include nodes. Node IP addresses were incorrect as the host facts were only being processed once.