### PR TITLE
Ansible playbook fix ceph vs walrus settings

### DIFF
--- a/ansible/roles/ceph-common/defaults/main.yml
+++ b/ansible/roles/ceph-common/defaults/main.yml
@@ -7,7 +7,7 @@ ceph_cluster_network: "{{ ceph_public_network }}"
 
 ceph_osd_data_path: /var/lib/ceph-osd/osd0
 
-ceph_facts: "{{ True if ('ceph' in groups and groups['ceph'] and not inventory_hostname in groups['ceph']) else False }}"
+ceph_facts: "{{ True if ('ceph' in groups and groups['ceph']) else False }}"
 
 cloud_firewalld_configure: no
 

--- a/ansible/roles/ceph/meta/main.yml
+++ b/ansible/roles/ceph/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
-  - role: ceph-common
+- role: ceph-common
+  vars:
+    ceph_facts: no

--- a/ansible/roles/cloud/tasks/main.yml
+++ b/ansible/roles/cloud/tasks/main.yml
@@ -117,7 +117,7 @@
     port: 8773
     timeout: 180
 
-- name: register services
+- name: register user facing and zone services
   shell: |
     UFS_HOSTS="{{ groups['cloud'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4']) | list | join(' ') }}"
     ZONE_HOSTS="{{ groups['zone'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4']) | list | join(' ') }}"
@@ -126,7 +126,6 @@
     
     for UFS_HOST in ${UFS_HOSTS} ; do
       euserv-register-service -t user-api -z API_${UFS_HOST} -h ${UFS_HOST} API_${UFS_HOST}
-      euserv-register-service -t walrusbackend -h ${UFS_HOST} WALRUS_${UFS_HOST}
     done
     
     for ZONE_HOST in ${ZONE_HOSTS} ; do
@@ -136,6 +135,16 @@
   register: shell_result
   until: shell_result.rc == 0
   retries: 5
+
+- name: register walrus backend service
+  shell: |
+    eval $(clcadmin-assume-system-credentials)
+    CLC_HOST={{ eucalyptus_host_cluster_ipv4 | quote  }}
+    euserv-register-service -t walrusbackend -h ${CLC_HOST} WALRUS_${CLC_HOST}
+  register: shell_result
+  until: shell_result.rc == 0
+  retries: 5
+  when: eucalyptus_ceph_conf is undefined
 
 - name: configure cloud properties
   shell: |


### PR DESCRIPTION
Modify ceph facts gathering for consistency and to enable single host installs with ceph. Do not register walrus backend service instance when using ceph.