### PR TITLE
Ansible playbook ceph logical volume provisioning

### DIFF
--- a/ansible/roles/ceph/tasks/ceph_install_deploy.yml
+++ b/ansible/roles/ceph/tasks/ceph_install_deploy.yml
@@ -66,6 +66,19 @@
   become: no
   when: ceph_osd_data_path is match("/.*") and ceph_osd_data_path is not match("/dev/.*")
 
+- name: logical volume for ceph osds
+  shell: |
+    VGLV_PATH={{ ceph_osd_data_path | quote }}
+    VG_NAME="${VGLV_PATH%%/*}"
+    LV_NAME="${VGLV_PATH##*/}"
+    if vgs "${VG_NAME}" && ! lvs "${VGLV_PATH}" ; then
+      lvcreate --extents 100%VG --addtag eucalyptus.provisioned=yes --name "${LV_NAME}" "${VG_NAME}"
+    fi
+  become: no
+  when: ceph_osd_data_path is match("[a-zA-Z0-9+_.-]+/[a-zA-Z0-9+_.-]+")
+  register: shell_result
+  changed_when: '"created" in shell_result.stdout'
+
 - name: create osds
   command:
     chdir: /home/ceph-deploy/cluster

--- a/ansible/roles/none/tasks/main.yml
+++ b/ansible/roles/none/tasks/main.yml
@@ -210,6 +210,23 @@
     path: /etc/ceph
     state: absent
 
+- name: unmount ceph temporary filesystems
+  shell: |
+    for CEPH_MOUNT in $(findmnt --type tmpfs --mtab --raw --noheadings | grep -oE '/var/lib/ceph/[a-zA-Z0-9_/-]+'); do
+      echo "Unmounting ${CEPH_MOUNT}"
+      umount "${CEPH_MOUNT}"
+    done
+  register: shell_result
+  changed_when: '"Unmounting" in shell_result.stdout'
+
+- name: remove provisioned ceph logical volumes
+  shell: |
+    for CEPH_LV_PATH in $(lvs --noheadings -o path @eucalyptus.provisioned=yes); do
+      lvremove --force "${CEPH_LV_PATH}"
+    done
+  register: shell_result
+  changed_when: '"successfully removed" in shell_result.stdout'
+
 - name: remove ceph state directory
   file:
     path: /var/lib/ceph


### PR DESCRIPTION
Ansible playbook ceph logical volume provisioning via `ceph_osd_data_path` variable. For example:

```
ceph_osd_data_path: "storage_vg/storage_lv"
```

Provisioned volumes are tagged for listing and clean up:

```
# lvs @eucalyptus.provisioned=yes
  LV         VG         Attr       LSize    Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  storage_lv storage_vg -wi-ao---- <200.00g
```