### PR TITLE
Ansible playbook midonet-nsdb role requires datastax/midonet repos

### DIFF
--- a/ansible/roles/midonet-nsdb/meta/main.yml
+++ b/ansible/roles/midonet-nsdb/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
-- role: ceph-common
+- role: common
   vars:
     ceph_facts: no
+    key_facts: no


### PR DESCRIPTION
Configure required repositories for midonet-nsdb role