### PR TITLE
Image catalog replace coreos with fedora coreos linux

### DIFF
--- a/images/image-catalog.json
+++ b/images/image-catalog.json
@@ -37,6 +37,16 @@
       "image-format": "raw"
     },
     {
+      "description": "Fedora CoreOS Stable",
+      "login": "core",
+      "url-meta": "https://builds.coreos.fedoraproject.org/streams/stable.json",
+      "url-meta-regex": "https://builds\\.coreos\\.fedoraproject\\.org/prod/streams/stable/builds/[a-z0-9/._-]{16,64}-aws\\.x86_64\\.vmdk\\.xz",
+      "updates": "no",
+      "architecture": "x86_64",
+      "os": "fcos",
+      "image-format": "vmdk"
+    },
+    {
       "description": "CentOS 7",
       "login": "centos",
       "url": "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.raw.tar.gz",
@@ -64,15 +74,6 @@
       "image-format": "qcow2"
     },
     {
-      "description": "CoreOS Container Linux Stable",
-      "login": "core",
-      "url": "https://stable.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2",
-      "updates": "yes",
-      "architecture": "x86_64",
-      "os": "coreos-stable",
-      "image-format": "qcow2"
-    },
-    {
       "description": "Flatcar Container Linux Stable",
       "login": "core",
       "url": "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2",
@@ -82,6 +83,6 @@
       "image-format": "qcow2"
     }
   ],
-  "version": "sjones4-01-20-20"
+  "version": "sjones4-01-31-20"
 }
 


### PR DESCRIPTION
Image catalog replace coreos with fedora coreos linux.

> ...Fedora CoreOS is now available for general use

> CoreOS Container Linux will be maintained for a few more months, and then will be declared end-of-life.

https://fedoramagazine.org/fedora-coreos-out-of-preview/

The installer script is updated to support getting the image url from a metadata file and for the vmdk format.