### PR TITLE
Nephoria tests container update for v5

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,14 +2,15 @@ FROM centos:7
 
 RUN yum -y install epel-release \
  && yum -y install make gcc git libffi-devel openssl-devel patch \
-    python-devel python2-pip readline-devel libyaml-devel \
- && pip install --upgrade pip setuptools \
+    python-devel python2-pip readline-devel libyaml-devel net-tools \
+ && pip install --upgrade pip \
+ && pip install --upgrade setuptools \
  && cd /root \
  && git clone --depth 1 https://github.com/eucalyptus/adminapi.git \
  && cd adminapi \
  && python setup.py install \
  && cd /root \
- && git clone --depth 1 --branch devel-4.4 https://github.com/sjones4/nephoria.git \
+ && git clone --depth 1 --branch devel-5 https://github.com/sjones4/nephoria.git \
  && cd nephoria \
  && python setup.py install \
  && cd /root \


### PR DESCRIPTION
Update nephoria container image build for latest centos and switch to the v5 branch