### PR TITLE
Console image build update to require elastic ip association

### DIFF
--- a/build/build-eucalyptus-console-image.sh
+++ b/build/build-eucalyptus-console-image.sh
@@ -99,7 +99,7 @@ AssertPathExists=/etc/eucaconsole/elastic-ip-allocation.txt
 [Service]
 Restart=on-failure
 RestartSec=60
-ExecStartPre=-/usr/bin/sh /usr/local/bin/eucaconsole-elastic-ip
+ExecStartPre=/usr/bin/sh /usr/local/bin/eucaconsole-elastic-ip
 EOF
 
 cat > "${IMAGE_MOUNT}/etc/systemd/system/eucaconsole.path" << "EOF"


### PR DESCRIPTION
The `eucaconsole.service` elastic ip drop-in should require a successful association before the console starts. If the ip is not associated then the console will not be reachable by DNS name.